### PR TITLE
added support for gzipped image devices

### DIFF
--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -594,7 +594,13 @@ class ObjectQueryMiddleware(object):
                         untar_stream.offset_data = info.offset_data
                         for data in untar_stream.untar_file_iter():
                             if gzip:
-                                data = gzip.decompress(data)
+                                try:
+                                    data = gzip.decompress(data)
+                                except zlib.error:
+                                    return HTTPUnprocessableEntity(
+                                        request=req,
+                                        body='Failed to inflate gzipped image',
+                                        headers=nexe_headers)
                             fp.write(data)
                             perf = "%s %s:%.3f" % (perf, info.name, time.time() - start)
                         fp.close()


### PR DESCRIPTION
You can now supply *.tar.gz files as image device
The server will inflate the file on the final pipeline stage, before passing the image.tar to zerovm session

To signal that the gzipped file is used, you must set content type to "application/x-gzip" when uploading such files to Swift

Please note that setting "content_type" property in the json servlet file will have **no effect**, and will lead to error if the actual content type on Swift object is not "application/x-gzip"
