### PR TITLE
add isinstance check to ObjPath equals operator

### DIFF
--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -168,11 +168,15 @@ class ObjPath:
         self.path = path
 
     def __eq__(self, other):
+        if not isinstance(other, ObjPath):
+            return False
         if self.url == other.url:
             return True
         return False
 
     def __ne__(self, other):
+        if not isinstance(other, ObjPath):
+            return True
         if self.url != other.url:
             return True
         return False


### PR DESCRIPTION
ObjPath class **eq** and **ne** operators were not checking that instance of the ObjPath class was passed to them
