### PR TITLE
fix for calling non-existent Controller methods

### DIFF
--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -1065,7 +1065,7 @@ class ClusterController(ObjectController):
                 else:
                     server_response = conn.getresponse()
         except (Exception, Timeout):
-            self.exception_occurred(
+            self.app.exception_occurred(
                 conn.node, _('Object'),
                 _('Trying to get final status of POST to %s')
                 % request.path_info)
@@ -1181,7 +1181,8 @@ class ClusterController(ObjectController):
                     conn.resp = resp
                     return conn
                 elif resp.status == HTTP_INSUFFICIENT_STORAGE:
-                    self.error_limit(node, _('ERROR Insufficient Storage'))
+                    self.app.error_limit(node,
+                                         _('ERROR Insufficient Storage'))
                 elif is_client_error(resp.status):
                     conn.error = resp.read()
                     conn.resp = resp
@@ -1190,9 +1191,9 @@ class ClusterController(ObjectController):
                     self.app.logger.warn('Obj server failed with: %d %s'
                                          % (resp.status, resp.reason))
             except Exception:
-                self.exception_occurred(node, _('Object'),
-                                        _('Expect: 100-continue on %s')
-                                        % request.path_info)
+                self.app.exception_occurred(node, _('Object'),
+                                            _('Expect: 100-continue on %s')
+                                            % request.path_info)
 
     def _store_accounting_data(self, request, connection=None):
         txn_id = request.environ['swift.trans_id']


### PR DESCRIPTION
looks like Swift changes from 11/22/2013 placed error_limit() and exception_occurred() methods under Application class and not under Controller
this change fixes it by calling these methids through app handle that points to Application class
