### PR TITLE
added missing handler for interpreter arguments

### DIFF
--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -55,7 +55,7 @@ POST_TEXT_ACCOUNT_SYSTEM_MAP = r'''
         "name": "script",
         "exec": {
             "path": "{.exe_path}",
-            "args": "script"
+            "args": "{.args}script"
         },
         "file_list": [
             {
@@ -71,7 +71,7 @@ POST_TEXT_OBJECT_SYSTEM_MAP = r'''
         "name": "script",
         "exec": {
             "path": "{.exe_path}",
-            "args": "script"
+            "args": "{.args}script"
         },
         "file_list": [
             {

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -803,6 +803,8 @@ class ClusterController(ObjectController):
             if len(command_line) > 1:
                 args = command_line[1]
             params = {'exe_path': exe_path}
+            if args:
+                params['args'] = args.strip() + " "
             if self.container_name and self.object_name:
                 template = POST_TEXT_OBJECT_SYSTEM_MAP
                 location = SwiftPath.init(self.account_name,


### PR DESCRIPTION
when text is POSTed as an executable job (using X-Zerovm-Execute header)
the shebang line can contain not only path to interpreter but also interpreter command line args
this change adds handling for these args, now the args are properly inserted into nvram file

brief digression:
format of shebang line is not standardized in POSIX or any other *NIX documentation
most systems "safely" assume that shebang does not contain anything but path to the interpreter
but in Linux and some other modern systems shebang can contain command line arguments
this is why it's handled here
