### PR TITLE
fix nvram test to not rely on line order

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -1278,10 +1278,9 @@ return open(mnfst.nvram['path']).read()
         res = req.get_response(prosrv)
         self.assertIn('[args]\n'
                       'args = sort\n', res.body)
-        self.assertIn('[mapping]\n'
-                      'channel=/dev/input, mode=file\n'
-                      'channel=/dev/stdout, mode=char\n',
-                      res.body)
+        self.assertIn('[mapping]', res.body)
+        self.assertIn('channel=/dev/input, mode=file', res.body)
+        self.assertIn('channel=/dev/stdout, mode=char', res.body)
 
     def test_QUERY_sort_immediate_stdout_stderr(self):
         self.setup_QUERY()

--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -1254,8 +1254,9 @@ return open(mnfst.nvram['path']).read()
         self.assertIn('[args]\n'
                       'args = sort aa bb cc',
                       res.body)
-        self.assertIn('name=key2, value=val2\n'
-                      'name=key1, value=val1',
+        self.assertIn('name=key1, value=val1',
+                      res.body)
+        self.assertIn('name=key2, value=val2',
                       res.body)
 
         conf = [


### PR DESCRIPTION
order of k/v pairs in nvram file is not important
