### PR TITLE
changed the /dev/image channel type to 3

### DIFF
--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -13,7 +13,7 @@ CHANNEL_TYPE_MAP = {
     'input': 3,
     'output': 3,
     'debug': 0,
-    'image': 1,
+    'image': 3,
     'sysimage': 3
 }
 ENV_ITEM = 'name=%s, value=%s\n'


### PR DESCRIPTION
the /dev/image default channel type was always 1 (append-only channel)
but with recent developments in zrt and future introduction of real append-only channels it should be moved to 3 (randomly readable)
