### PR TITLE
added new servlet job feature: attach

### DIFF
--- a/doc/Servlets.md
+++ b/doc/Servlets.md
@@ -31,7 +31,8 @@ JSON format describing a servlet configuration
             "nodename1",
             "nodename2"
         ],
-        "replicate":1 <i>how many replicas of this node should run, optional</i>
+        "replicate":1, <i>how many replicas of this node should run, optional</i>
+        "attach": "default" <i>where zerovm session will be attached, optional, see below</i>
         }
     ,
     ....
@@ -52,14 +53,13 @@ JSON format describing a servlet configuration
     debug
     </pre>
 
-    _All other device names are invalid_
+    _All other device names are invalid_  
+    There are also 'system images' which are devices as well.  
+    If `zerovm_sysimage_devices` is set in proxy and object server config files  
+    you can use the device names you've set there in servlet config  
+    and they are added to the list of allowed device names.  
 
-    There are also 'system images' which are devices as well.
-    If `zerovm_sysimage_devices` is set in proxy and object server config files
-    you can use the device names you've set there in servlet config
-    and they are added to the list of allowed device names.
-
-2. `file_list[i].path` is optional
+2. Path property `file_list[i].path` is optional  
 Only the following devices can be supplied without `path` property set
 
     <pre>
@@ -68,22 +68,20 @@ Only the following devices can be supplied without `path` property set
     output
     </pre>
 
-    All other devices must have a path attribute. There can be
-    *exactly one* output device without a path.
-
+    All other devices must have a path attribute. There can be *exactly one* output device without a path.  
     If the device is a 'system image' it also does not have a path,
     its path is predefined in `zerovm_sysimage_devices` configuration directive
 
-3. `file_list[i].path` can contain wild-card(s)
-`*` character must be used as wild-card
-Any number of wild-cards is allowed in one path
-Wild-cards are expanded following the `/.*/` regex rule
-If path contains wild-card the `count` is ignored
-`debug` device cannot have a wild-card in path
+3. Path property `file_list[i].path` can contain wild-card(s)  
+Asterisk `*` character must be used as wild-card  
+Any number of wild-cards is allowed in one path  
+Wild-cards are expanded following the `/.*/` regex rule  
+If path contains wild-card the `count` is ignored  
+`debug` device cannot have a wild-card in path  
 
 4. If all devices in `file_list` do not contain path
-or there are 0 devices in `file_list` a `count` should be supplied
-If `count` is not supplied `count: 1` is assumed
+or there are 0 devices in `file_list` a `count` should be supplied  
+If `count` is not supplied `count: 1` is assumed  
 
 5. If the following devices have wild-cards in path
 
@@ -103,16 +101,16 @@ If `count` is not supplied `count: 1` is assumed
 
     Or they can have no path attribute (if it's allowed for this device)
 
-6. `connect` list represents one way directed connection from this node to the nodes in `connect`
-The current node is a source of the connection and each node in `connect` is a destination
+6. Connection list `"connect": []` represents one-way directed connection from this node to the nodes in `connect`  
+The current node is a source of the connection and each node in `connect` is a destination  
 Node can be connected to itself if and only if its `count` > 1 implicitly (by having path with wild-card) or explicitly by having `count` property set
 
-7. `args` represents a command line as a string
+7. Argument string `args` represents a command line as a string  
 Command line should be supplied by user
 
-8. `env` represents an execution environment as key->value hash
-Keys must be unique
-Keys and values should be supplied by user
+8. Env dictionary `env` represents an execution environment as key->value hash  
+Keys must be unique  
+Keys and values should be supplied by user  
 Keys must be alphanumeric, cannot contain whitespace characters
 
 9. There are the following device types
@@ -140,22 +138,22 @@ Keys must be alphanumeric, cannot contain whitespace characters
 
     All system image devices are <i>RANDOM + READABLE</i>
 
-10. `debug` is a special network device
-It must have `path` property set
-Its path has the following semantics:
-`proto://hostname:port`
-Where proto must be one of:
+10. Device `debug` is a special network device  
+    It must have `path` property set  
+    Its path has the following semantics:  
+    `proto://hostname:port`  
+    Where proto must be one of:
 
     <pre>
     tcp
     udp
     </pre>
 
-Port must be numeric
-`hostname` must be a valid hostname, allowed characters: `alphanumeric`, `.`, `-`
+    Port must be numeric  
+    `hostname` must be a valid hostname, allowed characters: `alphanumeric`, `.`, `-`
 
-11. Each `path` must start with `/` character
-The following devices _must_ have existing, readable path:
+11. Each `path` must start with `/` character  
+    The following devices _must_ have existing, readable path:
 
     <pre>
     stdin
@@ -163,50 +161,56 @@ The following devices _must_ have existing, readable path:
     image
     </pre>
 
-    `exec` property _must_ have existing, readable `path`
-    `exec` property can have a relative path (not starting with `/`).
+    `exec` property _must_ have existing, readable `path`  
+    `exec` property can have a relative path (not starting with `/`).  
     If the `path` is relative it is assumed that executable file
-    is archived inside `image` device or any of the `system image` devices.
+    is archived inside `image` device or any of the `system image` devices.  
     First the `image` device is checked for the relative path, then all the `system image`
     devices are checked in the order they appear in config file, the process stops when the file is found.
 
-12. Device can have `content_type` property set. Its value will be posted as a `Content-Type` header for this object.
-`content_type` makes sense only for `WRITABLE` devices as it won't change existing content types just write new ones.
-The `Content-Type` for a device without a `path` property will be set for the HTTP response.
+12. Device can have `content_type` property set. Its value will be posted as a `Content-Type` header for this object.  
+`content_type` makes sense only for `WRITABLE` devices as it won't change existing content types just write new ones.  
+The `Content-Type` for a device without a `path` property will be set for the HTTP response.  
 `content_type` property set for read-only devices will be ignored.
 
-13. Device with `content_type: message/http` or `content_type: message/cgi` has a special meaning.
-The output object of such device will be parsed as an HTTP response.
+13. Device with `content_type: message/http` or `content_type: message/cgi` has a special meaning.  
+The output object of such device will be parsed as an HTTP response.  
 Headers taken from the parsed response will be supplied either to PUT if this object to be saved in object store,
-or in the response if it is an immediate response object (no `path` set)
-Only the following headers will be parsed from this object: `Content-Type` `X-Object-Meta-*`
-`message/http` is for CGI NPH applications and `message/cgi` is for regular CGI applications.
+or in the response if it is an immediate response object (no `path` set)  
+Only the following headers will be parsed from this object: `Content-Type` `X-Object-Meta-*`  
+`message/http` is for CGI NPH applications and `message/cgi` is for regular CGI applications.  
 CGI/1.1 is supported on server, CGI environment variables will be supplied to the application.
 
-14. Device can have `meta` property set. `meta` contains meta-tag dictionary for this object.
-The meta-tags will be written alongside the object when the object is saved.
-Meta-tags will be sent within HTTP response if it is an immediate response object (no `path` set).
+14. Device can have `meta` property set. `meta` contains meta-tag dictionary for this object.  
+The meta-tags will be written alongside the object when the object is saved.  
+Meta-tags will be sent within HTTP response if it is an immediate response object (no `path` set).  
 `meta` will be ignored for read-only objects.
 
-15. Each node can have `replicate` property set. Default replication value is 1 (no replication).
-This property supports `replicate: 2` and `replicate: 3` for double and triple replication respectively.
-If it was set to > 1 additional copies of the node will run.
-Zerovm will replicate channels data for these nodes and compare them at runtime.
-If it encounters errors the data from these nodes will be temporarily ignored.
-This feature allows cluster to be fault-tolerant and improves the cluster processing speeds slightly.
-Zerocloud may decide to run specific nodes in replicated way even when it was not specified in the servlet config file.
+15. Each node can have `replicate` property set. Default replication value is 1 (no replication).  
+This property supports `replicate: 2` and `replicate: 3` for double and triple replication respectively.  
+If it was set to > 1 additional copies of the node will run.  
+Zerovm will replicate channels data for these nodes and compare them at runtime.  
+If it encounters errors the data from these nodes will be temporarily ignored.  
+This feature allows cluster to be fault-tolerant and improves the cluster processing speeds slightly.  
+Zerocloud may decide to run specific nodes in replicated way even when it was not specified in the servlet config file.  
 It does so to add redundancy or set replicas for the resulting Swift objects directly.
 
-16. Some applications may expect devices/channels to produce specific output when stat() is run on the descriptor.
-You can change the type of the file with the `mode` property of the `device`.
-The types are:
-`file` - regular file
-`char` - character device
-`pipe` - FIFO pipe (default for standard channels `stdin` `stdout` `stderr`)
-`block` - block device (default for all other channels)
-The most useful combinations are: `file` instead of `block` and `char` instead of `pipe`.
+16. Some applications may expect devices/channels to produce specific output when stat() is run on the descriptor.  
+You can change the type of the file with the `mode` property of the `device`.  
+The types are:  
+`file` - regular file  
+`char` - character device  
+`pipe` - FIFO pipe (default for standard channels `stdin` `stdout` `stderr`)  
+`block` - block device (default for all other channels)  
+The most useful combinations are: `file` instead of `block` and `char` instead of `pipe`.  
 Other combinations are supported but make little sense.
 
+17. Some users may want to control where the session will be started.  
+To colocate the session with the largest object, for example. Or to faster write the output file/object.  
+It can be controlled with the `attach` keyword.  
+Default value for attach is `default` which means that the following strategy will be employed by middleware: _code will be sent to the storage node that holds the first (topmost) `swift://` path encountered in the job config. But before that the paths will be sorted by placing `read only` objects on top, `write only` after the former ones, and all other objects at the bottom. Sort will be a stable one. If such path does not exist the node for a session will be chosen randomly._  
+If another location is desired, user needs to specify a device in `attach`, ex.: `"attach": "stdout"`.  
+If the device is a `swift://` path the session will be started in co-location with the desired object. If such device is not a `swift://` path the node for a session will be chosen randomly.
 
 ## Examples
 

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -286,7 +286,7 @@ def is_cache_path(location):
 
 class ZvmNode(object):
     def __init__(self, id=None, name=None, exe=None, args=None, env=None,
-                 replicate=1):
+                 replicate=1, attach=None):
         self.id = id
         self.name = name
         self.exe = exe
@@ -299,6 +299,7 @@ class ZvmNode(object):
         self.replicas = []
         self.skip_validation = False
         self.wildcards = None
+        self.attach = attach
 
     def copy(self, id, name=None):
         newnode = deepcopy(self)

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -333,7 +333,7 @@ class ClusterConfigParser(object):
             self.node_list.append(self.nodes[node_name])
         if add_user_image:
             for node in self.node_list:
-                    node.add_new_channel('image', ACCESS_CDR, removable='yes')
+                node.add_new_channel('image', ACCESS_CDR, removable='yes')
         if account_name:
             self.resolve_path_info(account_name, replica_count)
         self.total_count = 0
@@ -665,7 +665,13 @@ class ClusterConfigParser(object):
                     node.exe = SwiftPath.init(account_name,
                                               node.exe.container,
                                               node.exe.obj)
-            top_channel = node.channels[0]
+            if node.attach == 'default':
+                top_channel = node.channels[0]
+            else:
+                for chan in node.channels:
+                    if node.attach == chan.device:
+                        top_channel = chan
+                        break
             if top_channel and is_swift_path(top_channel.path):
                 if top_channel.access & (ACCESS_READABLE | ACCESS_CDR):
                     node.path_info = top_channel.path.path
@@ -734,7 +740,8 @@ def _create_node(node_config):
         raise ClusterConfigParsingError(
             _('Invalid nexe property for %s') % name)
     replicate = node_config.get('replicate', 1)
-    return ZvmNode(0, name, exe, args, env, replicate)
+    attach = node_config.get('attach', 'default')
+    return ZvmNode(0, name, exe, args, env, replicate, attach)
 
 
 def _create_channel(channel, node, default_content_type=None):

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -611,12 +611,12 @@ class ClusterController(ObjectController):
         channels = []
         if is_swift_path(node.exe):
             channels.append(ZvmChannel('boot', None, path=node.exe))
-        if len(node.channels) > 1:
-            for ch in node.channels[1:]:
-                if is_swift_path(ch.path) \
+        for ch in node.channels:
+            if is_swift_path(ch.path) \
                     and (ch.access & (ACCESS_READABLE | ACCESS_CDR)) \
-                        and not self.parser.is_sysimage_device(ch.device):
-                    channels.append(ch)
+                    and not self.parser.is_sysimage_device(ch.device) \
+                    and ch.path.path != getattr(node, 'path_info', None):
+                channels.append(ch)
         return channels
 
     def _create_request_for_remote_object(self, data_sources, channel,


### PR DESCRIPTION
`attach` makes it possible to attach a job (ZeroVM session) to one of the devices specified in json job config.
It means that the executable and all other objects will be copied to the node that contains that object, and the code will be executed on that node.
Obviously it does make sense only if the device path is a Swift one.

Documentation was also fixed to reflect the new `attach` property.
