### PR TITLE
rework account home to support globbing patterns

### DIFF
--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -86,6 +86,8 @@ POST_TEXT_OBJECT_SYSTEM_MAP = r'''
     }]
 '''
 
+ACCOUNT_HOME_PATH = ['.', '~']
+
 MD5HASH_LENGTH = len(md5('').hexdigest())
 REPORT_LENGTH = 6
 REPORT_VALIDATOR = 0
@@ -160,6 +162,14 @@ def can_run_as_daemon(node_conf, daemon_conf):
         if n.device not in d.device:
             return False
     return True
+
+
+def expand_account_path(account_name, path):
+    if path.account in ACCOUNT_HOME_PATH:
+        return SwiftPath.init(account_name,
+                              path.container,
+                              path.obj)
+    return path
 
 
 class ObjPath:


### PR DESCRIPTION
rework and fix behavior of c567b1012b80cbd23d2aeeb7b71e018ac99b948f
- now supports `.` (dot) or `~` (tilde) as a current account in Swift URLs
- now the expansion happens earlier and the globbing patterns work with it, i.e. `swift://~/c/obj*` will be correctly handled
