### PR TITLE
added support for "opaque" networking

### DIFF
--- a/test/unit/zerovm_mock.py
+++ b/test/unit/zerovm_mock.py
@@ -210,6 +210,8 @@ for fname, device, type, tag, rd, rd_byte, wr, wr_byte \
                 connect_data += struct.pack('!IH', host, 0)
                 connect_count += 1
                 con_list.append(device)
+    elif fname.startswith('opaque:'):
+        con_list.append([fname, device])
     mnfst.channels[device] = {
         'device': device,
         'path': fname,


### PR DESCRIPTION
in preparation for zerovm interface v2.0 added support for opaque network handles
although the semantic meaning of handle is just random string the current mask is as following:

```
<cluster id>-<source node id>-<dest node id>
```
