### PR TITLE
support for running jobs over container sqlite3 database file

### DIFF
--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -13,6 +13,7 @@ from eventlet.green import socket
 from tempfile import mkdtemp
 from shutil import rmtree
 from test import get_config
+from textwrap import dedent
 from swift.common.utils import config_true_value
 from hashlib import md5
 from eventlet import sleep, Timeout
@@ -444,3 +445,7 @@ def create_tar(name_and_file):
             os.unlink(tarname)
         except OSError:
             pass
+
+
+def trim(script):
+    return dedent(script[1:-1])

--- a/test/unit/test_containerquery.py
+++ b/test/unit/test_containerquery.py
@@ -1,0 +1,149 @@
+import os
+import tarfile
+from tempfile import mkdtemp, mkstemp
+import unittest
+from shutil import rmtree
+from hashlib import md5
+from StringIO import StringIO
+from swift.common import utils
+from swift.common.swob import Request
+from swift.common.utils import mkdirs
+from swift.container.server import ContainerController
+from test.unit import FakeLogger, create_tar, trim
+from test.unit.test_proxyquery import ZEROVM_DEFAULT_MOCK
+from zerocloud import objectquery
+from zerocloud.common import ZvmNode, parse_location, ACCESS_READABLE, \
+    ACCESS_WRITABLE, NodeEncoder
+from zerocloud.thread_pool import Zuid
+from eventlet.wsgi import Input
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+
+class FakeApp(ContainerController):
+    def __init__(self, conf):
+        ContainerController.__init__(self, conf)
+        self.bytes_per_sync = 1
+        self.fault = False
+
+    def __call__(self, env, start_response):
+        if self.fault:
+            raise Exception
+        ContainerController.__call__(self, env, start_response)
+
+
+class TestContainerQuery(unittest.TestCase):
+
+    def setUp(self):
+        utils.HASH_PATH_SUFFIX = 'endcap'
+        self.testdir = \
+            os.path.join(mkdtemp(),
+                         'tmp_test_container_server_ContainerController')
+        mkdirs(os.path.join(self.testdir, 'sda1', 'tmp'))
+        self.conf = {'devices': self.testdir,
+                     'mount_check': 'false',
+                     'disable_fallocate': 'true',
+                     'zerovm_sysimage_devices':
+                         'sysimage1 /opt/zerovm/sysimage1 '
+                         'sysimage2 /opt/zerovm/sysimage2'
+        }
+        self.cont_controller = FakeApp(self.conf)
+        self.app = objectquery.ObjectQueryMiddleware(self.cont_controller,
+                                                     self.conf,
+                                                     logger=FakeLogger())
+        self.app.zerovm_maxoutput = 1024 * 1024 * 10
+        self.zerovm_mock = None
+        self.uid_generator = Zuid()
+        self.create_container()
+
+    def tearDown(self):
+        rmtree(os.path.dirname(self.testdir))
+        if self.zerovm_mock:
+            os.unlink(self.zerovm_mock)
+
+    def setup_zerovm_query(self, mock=None):
+        # ensure that python executable is used
+        zerovm_mock = ZEROVM_DEFAULT_MOCK
+        if mock:
+            fd, zerovm_mock = mkstemp()
+            os.write(fd, mock)
+            os.close(fd)
+            self.zerovm_mock = zerovm_mock
+        self.app.zerovm_exename = ['python', zerovm_mock]
+        # do not set it lower than 2 * BLOCKSIZE (2 * 512)
+        # it will break tar RPC protocol
+        self.app.app.network_chunk_size = 2 * 512
+
+    def create_container(self, url='/sda1/p/a/c'):
+        req = Request.blank(
+            url, environ={'REQUEST_METHOD': 'PUT',
+                          'HTTP_X_TIMESTAMP': '1'})
+        resp = req.get_response(self.app)
+        self.assertEquals(resp.status_int, 201)
+
+    def add_object(self, url='/sda1/p/a/c', name='o'):
+        req = Request.blank(
+            '/'.join((url, name)), environ={'REQUEST_METHOD': 'PUT'},
+            headers={'X-Timestamp': '1', 'X-Size': '0',
+                     'X-Content-Type': 'text/plain', 'X-ETag': 'e'})
+        resp = req.get_response(self.app)
+        print resp.body
+        self.assertEquals(resp.status_int, 201)
+
+    def zerovm_container_request(self):
+        req = Request.blank('/sda1/p/a/c',
+                            environ={'REQUEST_METHOD': 'POST'},
+                            headers={'Content-Type': 'application/x-gtar',
+                                     'x-zerovm-execute': '1.0',
+                                     'x-account-name': 'a'})
+        req.headers['x-zerocloud-id'] = self.uid_generator.get()
+        return req
+
+    def test_select_object_names(self):
+        self.setup_zerovm_query()
+        self.add_object(name='o1')
+        self.add_object(name='o2')
+        self.add_object(name='o3')
+        req = self.zerovm_container_request()
+        nexescript = trim(r'''
+            import sqlite3
+            db_path = mnfst.channels['/dev/input']['path']
+            con = sqlite3.connect(db_path)
+            cursor = con.cursor()
+            cursor.execute("SELECT name FROM object;")
+            l = []
+            for r in cursor.fetchall():
+                l.append(str(r[0]))
+            return json.dumps(l)
+            ''')
+        nexefile = StringIO(nexescript)
+        conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
+        conf.add_new_channel('input', ACCESS_READABLE,
+                             parse_location('swift://a/c'))
+        conf.add_new_channel('stdout', ACCESS_WRITABLE)
+        conf = json.dumps(conf, cls=NodeEncoder)
+        sysmap = StringIO(conf)
+        with create_tar({'boot': nexefile, 'sysmap': sysmap}) as tar:
+            length = os.path.getsize(tar)
+            req.body_file = Input(open(tar, 'rb'), length)
+            req.content_length = length
+            resp = self.app.zerovm_query(req)
+            fd, name = mkstemp()
+            self.assertEqual(resp.status_int, 200)
+            for chunk in resp.app_iter:
+                os.write(fd, chunk)
+            os.close(fd)
+            self.assertEqual(os.path.getsize(name), resp.content_length)
+            tar = tarfile.open(name)
+            names = tar.getnames()
+            self.assertIn('stdout', names)
+            members = tar.getmembers()
+            result = None
+            for m in members:
+                if 'stdout' in m.name:
+                    result = json.loads(tar.extractfile(m).read())
+                    self.assertEqual(result, ['o1', 'o2', 'o3'])
+            self.assertIsNotNone(result)

--- a/test/unit/test_containerquery.py
+++ b/test/unit/test_containerquery.py
@@ -3,7 +3,6 @@ import tarfile
 from tempfile import mkdtemp, mkstemp
 import unittest
 from shutil import rmtree
-from hashlib import md5
 from StringIO import StringIO
 from swift.common import utils
 from swift.common.swob import Request

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -267,6 +267,10 @@ class ClusterConfigParser(object):
                         if is_swift_path(channel.path):
                             channel.path = expand_account_path(account_name,
                                                                channel.path)
+                            if not channel.path.obj \
+                                    and not channel.access & ACCESS_READABLE:
+                                raise ClusterConfigParsingError(
+                                    'Container path must be read-only')
                         if channel.access < 0:
                             if self.is_sysimage_device(channel.device):
                                 other_list.append(channel)
@@ -312,9 +316,6 @@ class ClusterConfigParser(object):
                                 self._add_new_channel(zvm_node, chan)
                     for chan in write_list:
                         if chan.path and is_swift_path(chan.path):
-                            if not chan.path.obj:
-                                raise ClusterConfigParsingError(
-                                    'Container path is not writable')
                             if '*' in chan.path.url:
                                 if read_group:
                                     for i in range(1, node_count + 1):

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -118,6 +118,9 @@ class ClusterConfigParser(object):
         :raises ClusterConfigParsingError: on all other errors
         """
         temp_list = []
+        if '*' in path.account:
+            raise ClusterConfigParsingError('Invalid path: %s'
+                                            % path.url)
         if '*' in path.container:
             mask = re.compile(re.escape(path.container).replace('\\*', '.*'))
             try:
@@ -136,18 +139,23 @@ class ClusterConfigParser(object):
             else:
                 mask = None
             for container in containers:
-                try:
-                    obj_list = self.list_container(path.account,
-                                                   container,
-                                                   mask=mask, **kwargs)
-                except Exception:
-                    raise ClusterConfigParsingError(
-                        'Error querying object server '
-                        'for container: %s' % container)
-                for obj in obj_list:
+                if mask:
+                    try:
+                        obj_list = self.list_container(path.account,
+                                                       container,
+                                                       mask=mask, **kwargs)
+                    except Exception:
+                        raise ClusterConfigParsingError(
+                            'Error querying object server '
+                            'for container: %s' % container)
+                    for obj in obj_list:
+                        temp_list.append(SwiftPath.init(path.account,
+                                                        container,
+                                                        obj))
+                else:
                     temp_list.append(SwiftPath.init(path.account,
                                                     container,
-                                                    obj))
+                                                    None))
         else:
             obj = re.escape(path.obj).replace('\\*', '.*')
             mask = re.compile(obj)
@@ -277,7 +285,8 @@ class ClusterConfigParser(object):
 
                     read_group = False
                     for chan in read_list:
-                        if '*' in chan.path.path:
+                        if is_swift_path(chan.path) \
+                                and '*' in chan.path.path:
                             read_group = True
                             object_list = self.find_objects(chan.path,
                                                             **kwargs)
@@ -301,40 +310,47 @@ class ClusterConfigParser(object):
                                                           index=i)
                             else:
                                 self._add_new_channel(zvm_node, chan)
-
                     for chan in write_list:
-                        if chan.path and '*' in chan.path.url:
-                            if read_group:
-                                for i in range(1, node_count + 1):
-                                    new_node = self.nodes.get(
-                                        _create_node_name(zvm_node.name, i))
-                                    new_url = \
-                                        _extract_stored_wildcards(chan.path,
-                                                                  new_node)
-                                    new_loc = parse_location(new_url)
-                                    new_node.add_channel(channel=chan,
-                                                         path=new_loc)
-                            else:
-                                for i in range(1, node_count + 1):
-                                    new_name = \
-                                        _create_node_name(zvm_node.name, i)
-                                    new_url = \
-                                        chan.path.url.replace('*', new_name)
-                                    new_loc = parse_location(new_url)
-                                    new_node = self._add_new_channel(
-                                        zvm_node,
-                                        chan,
-                                        index=i,
-                                        path=new_loc)
-                                    new_node.wildcards = \
-                                        [new_name] * chan.path.url.count('*')
-                        elif chan.path:
-                            if node_count > 1:
+                        if chan.path and is_swift_path(chan.path):
+                            if not chan.path.obj:
                                 raise ClusterConfigParsingError(
-                                    'Single path %s for multiple node '
-                                    'definition: %s, please use wildcard'
-                                    % (chan.path.url, zvm_node.name))
-                            self._add_new_channel(zvm_node, chan)
+                                    'Container path is not writable')
+                            if '*' in chan.path.url:
+                                if read_group:
+                                    for i in range(1, node_count + 1):
+                                        new_node = self.nodes.get(
+                                            _create_node_name(
+                                                zvm_node.name, i))
+                                        new_url = \
+                                            _extract_stored_wildcards(
+                                                chan.path,
+                                                new_node)
+                                        new_loc = parse_location(new_url)
+                                        new_node.add_channel(channel=chan,
+                                                             path=new_loc)
+                                else:
+                                    for i in range(1, node_count + 1):
+                                        new_name = \
+                                            _create_node_name(zvm_node.name, i)
+                                        new_url = \
+                                            chan.path.url.replace('*',
+                                                                  new_name)
+                                        new_loc = parse_location(new_url)
+                                        new_node = self._add_new_channel(
+                                            zvm_node,
+                                            chan,
+                                            index=i,
+                                            path=new_loc)
+                                        new_node.wildcards = \
+                                            [new_name] * \
+                                            chan.path.url.count('*')
+                            else:
+                                if node_count > 1:
+                                    raise ClusterConfigParsingError(
+                                        'Single path %s for multiple node '
+                                        'definition: %s, please use wildcard'
+                                        % (chan.path.url, zvm_node.name))
+                                self._add_new_channel(zvm_node, chan)
                         else:
                             if 'stdout' not in chan.device \
                                     and 'stderr' not in chan.device:
@@ -367,6 +383,9 @@ class ClusterConfigParser(object):
             print traceback.format_exc()
             raise ClusterConfigParsingError('Config parser internal error')
 
+        if not self.nodes:
+            raise ClusterConfigParsingError('Config parser cannot resolve '
+                                            'any job nodes')
         for node in cluster_config:
             connection_list = node.get('connect')
             node_name = node.get('name')


### PR DESCRIPTION
you can query container data by connecting it to a specific read-only device (`/dev/input` is recommended)
the connected db will be raw read-only sqlite3 file, i.e. your code needs to know how to query it
The syntax for connecting to container db would be:

```
{
    "device": "input",
    "path": "swift://account/container"
}
```

you can use wildcards in container name, the rules are same as with objects
some examples:
`"path": "swift://account/*"` - query all containers, i.e. connect zerovm instance to each container db
`"path": "swift://account/*/*"` - query all objects, i.e. connect zerovm instance to each object (will be expensive)
