### PR TITLE
fixed tests to rely one their own Ring classes

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -2182,7 +2182,8 @@ return json.dumps(con_list)
 
         pqm = proxyquery.ProxyQueryMiddleware(
             self.proxy_app,
-            {'zerovm_sysimage_devices': 'sysimage1 sysimage2'})
+            {'zerovm_sysimage_devices': 'sysimage1 sysimage2'},
+            object_ring=FakeRing(), container_ring=FakeRing())
         conf = [
             {
                 'name': 'script',
@@ -2316,7 +2317,8 @@ return open(mnfst.nvram['path']).read()
 
         pqm = proxyquery.ProxyQueryMiddleware(
             self.proxy_app,
-            {'zerovm_sysimage_devices': 'sysimage1 sysimage2'})
+            {'zerovm_sysimage_devices': 'sysimage1 sysimage2'},
+            object_ring=FakeRing(), container_ring=FakeRing())
         conf = [
             {
                 'name': 'script',


### PR DESCRIPTION
some tests were relying on specific files in `/etc/swift`
removed that
