### PR TITLE
major bugfix patch for 404 errors

### DIFF
--- a/test/unit/test_containerquery.py
+++ b/test/unit/test_containerquery.py
@@ -97,7 +97,8 @@ class TestContainerQuery(unittest.TestCase):
                             environ={'REQUEST_METHOD': 'POST'},
                             headers={'Content-Type': 'application/x-gtar',
                                      'x-zerovm-execute': '1.0',
-                                     'x-account-name': 'a'})
+                                     'x-account-name': 'a',
+                                     'x-zerovm-access': 'GET'})
         req.headers['x-zerocloud-id'] = self.uid_generator.get()
         return req
 

--- a/test/unit/test_objectquery.py
+++ b/test/unit/test_objectquery.py
@@ -161,7 +161,8 @@ class TestObjectQuery(unittest.TestCase):
                             environ={'REQUEST_METHOD': 'POST'},
                             headers={'Content-Type': 'application/x-gtar',
                                      'x-zerovm-execute': '1.0',
-                                     'x-account-name': 'a'})
+                                     'x-account-name': 'a',
+                                     'x-zerovm-access': 'GET'})
         req.headers['x-zerocloud-id'] = self.uid_generator.get()
         return req
 
@@ -170,7 +171,8 @@ class TestObjectQuery(unittest.TestCase):
                             environ={'REQUEST_METHOD': 'POST'},
                             headers={'Content-Type': 'application/x-gtar',
                                      'x-zerovm-execute': '1.0',
-                                     'x-account-name': 'a'})
+                                     'x-account-name': 'a',
+                                     'x-zerovm-access': ''})
         req.headers['x-zerocloud-id'] = self.uid_generator.get()
         return req
 
@@ -552,7 +554,8 @@ return resp + out
                             headers={'Content-Type': 'application/x-gtar',
                                      'x-zerovm-execute': '1.0',
                                      'x-zerocloud-id': self.uid_generator.get(),
-                                     'x-timestamp': timestamp})
+                                     'x-timestamp': timestamp,
+                                     'x-zerovm-access': 'PUT'})
         with create_tar({'boot': nexefile, 'sysmap': sysmap}) as tar:
             length = os.path.getsize(tar)
             req.body_file = Input(open(tar, 'rb'), length)
@@ -596,7 +599,8 @@ return resp + out
                             headers={'Content-Type': 'application/x-gtar',
                                      'x-zerovm-execute': '1.0',
                                      'x-zerocloud-id': self.uid_generator.get(),
-                                     'x-timestamp': timestamp})
+                                     'x-timestamp': timestamp,
+                                     'x-zerovm-access': 'PUT'})
         with create_tar({'boot': nexefile, 'sysmap': sysmap}) as tar:
             length = os.path.getsize(tar)
             req.body_file = Input(open(tar, 'rb'), length)

--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -2165,6 +2165,141 @@ return json.dumps(con_list)
         self.assertEqual(res.status_int, 400)
         self.assertEqual(res.body, 'Invalid path swift://* in sort')
 
+    def test_local_device_path_404(self):
+        self.setup_QUERY()
+        prosrv = _test_servers[0]
+        for path in ('c/error', 'c/o/error', 'error'):
+            conf = [
+                {
+                    'name': 'sort',
+                    'exec': {'path': 'swift://a/c/exe',
+                             'args': ''},
+                    'file_list': [
+                        {'device': 'stdin',
+                         'path': 'swift://a/%s' % path},
+                        {'device': 'stdout'}
+                    ]
+                }
+            ]
+            conf = json.dumps(conf)
+            req = self.zerovm_request()
+            req.body = conf
+            res = req.get_response(prosrv)
+            self.assertEqual(res.status_int, 404)
+            self.assertEqual(res.body, 'Error %s while fetching '
+                                       '/a/%s' % (res.status, path))
+            self.assertEqual(res.headers['x-nexe-system'], 'sort')
+            self.assertEqual(res.headers['x-nexe-status'],
+                             'ZeroVM did not run')
+            self.assertEqual(res.headers['x-nexe-retcode'], '0')
+
+    def test_remote_device_path_404(self):
+        self.setup_QUERY()
+        prosrv = _test_servers[0]
+        for path in ('c/error', 'c/o/error'):
+            conf = [
+                {
+                    'name': 'sort',
+                    'exec': {'path': 'swift://a/c/exe',
+                             'args': ''},
+                    'file_list': [
+                        {'device': 'stdin',
+                         'path': 'swift://a/%s' % path},
+                        {'device': 'stdout'}
+                    ],
+                    'attach': 'stdout'
+                }
+            ]
+            conf = json.dumps(conf)
+            req = self.zerovm_request()
+            req.body = conf
+            res = req.get_response(prosrv)
+            self.assertEqual(res.status_int, 404)
+            self.assertEqual(res.body, 'Error %s while fetching '
+                                       '/a/%s' % (res.status, path))
+            self.assertEqual(res.headers['x-nexe-system'], 'sort')
+            self.assertEqual(res.headers['x-nexe-status'],
+                             'ZeroVM did not run')
+            self.assertEqual(res.headers['x-nexe-retcode'], '0')
+        for path in ('c/error', 'c/o/error'):
+            conf = [
+                {
+                    'name': 'sort',
+                    'exec': {'path': 'swift://a/c/exe',
+                             'args': ''},
+                    'file_list': [
+                        {'device': 'stdin',
+                         'path': 'swift://a/%s.in' % path},
+                        {'device': 'stdout',
+                         'path': 'swift://a/%s.out' % path}
+                    ],
+                    'attach': 'stdout'
+                }
+            ]
+            conf = json.dumps(conf)
+            req = self.zerovm_request()
+            req.body = conf
+            res = req.get_response(prosrv)
+            self.assertEqual(res.status_int, 404)
+            self.assertEqual(res.body, 'Error %s while fetching '
+                                       '/a/%s.in' % (res.status, path))
+            self.assertEqual(res.headers['x-nexe-system'], 'sort')
+            self.assertEqual(res.headers['x-nexe-status'],
+                             'ZeroVM did not run')
+            self.assertEqual(res.headers['x-nexe-retcode'], '0')
+        for path in ('c/error', 'c/o/error'):
+            conf = [
+                {
+                    'name': 'sort',
+                    'exec': {'path': 'swift://a/c/exe',
+                             'args': ''},
+                    'file_list': [
+                        {'device': 'stdin',
+                         'path': 'swift://a/%s.in' % path},
+                        {'device': 'stdout',
+                         'path': 'swift://a/%s.out' % path}
+                    ],
+                    'attach': 'stdin'
+                }
+            ]
+            conf = json.dumps(conf)
+            req = self.zerovm_request()
+            req.body = conf
+            res = req.get_response(prosrv)
+            self.assertEqual(res.status_int, 404)
+            self.assertEqual(res.body, 'Error %s while fetching '
+                                       '/a/%s.in' % (res.status, path))
+            self.assertEqual(res.headers['x-nexe-system'], 'sort')
+            self.assertEqual(res.headers['x-nexe-status'],
+                             'ZeroVM did not run')
+            self.assertEqual(res.headers['x-nexe-retcode'], '0')
+        for path in ('c/error', 'c/o/error'):
+            conf = [
+                {
+                    'name': 'sort',
+                    'exec': {'path': 'swift://a/c/exe',
+                             'args': ''},
+                    'file_list': [
+                        {'device': 'stdin',
+                         'path': 'swift://a/%s' % path},
+                        {'device': 'stdout',
+                         'path': 'swift://a/%s' % path}
+                    ],
+                    'attach': 'stdout'
+                }
+            ]
+            conf = json.dumps(conf)
+            req = self.zerovm_request()
+            req.body = conf
+            res = req.get_response(prosrv)
+            self.assertEqual(res.status_int, 200)
+            self.assertEqual(res.body, ('Could not resolve channel path: '
+                                        'swift://a/%s' % path) * 2)
+            self.assertEqual(res.headers['x-nexe-system'], 'sort,sort')
+            self.assertEqual(res.headers['x-nexe-status'],
+                             'ZeroVM did not run,ZeroVM did not run')
+            self.assertEqual(res.headers['x-nexe-retcode'], '0,0')
+
     def test_QUERY_account_server_error(self):
         with save_globals():
             swift.proxy.controllers.account.http_connect = \

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -314,6 +314,7 @@ class ZvmNode(object):
         self.skip_validation = False
         self.wildcards = None
         self.attach = attach
+        self.access = ''
 
     def copy(self, id, name=None):
         newnode = deepcopy(self)


### PR DESCRIPTION
a lot of 404 was not handled correctly due to badly designed support for write-only objects
it lead to 5xx instead of 404 or 400 in quite a few places
needed to redesign the whole thing and check for 404 much earlier than before

wrote some regression tests
hope that all corner cases are covered now

Side note:
This patch uses `x-zerovm-access` header internally. And its value can be `GET` or `PUT`. Usually adepts of RestFul will ask "Why not use HTTP GET and HTTP PUT instead?" my answer would be: "Think."
