### PR TITLE
use trans-id in opaque networks

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -2595,13 +2595,13 @@ return open(mnfst.nvram['path']).read()
             res = req.get_response(prosrv)
             self.assertEqual(res.status_int, 200)
             map_in = re.compile(
-                '/dev/in/map-\d+, opaque:local\|[\da-h]+-\d+-\d+')
+                '/dev/in/map-\d+, opaque:local\|[^-]+-\d+-\d+')
             map_out = re.compile(
-                '/dev/out/map-\d+, opaque:local\|>[\da-h]+-\d+-\d+')
+                '/dev/out/map-\d+, opaque:local\|>[^-]+-\d+-\d+')
             red_in = re.compile(
-                '/dev/in/red-\d+, opaque:local\|[\da-h]+-\d+-\d+')
+                '/dev/in/red-\d+, opaque:local\|[^-]+-\d+-\d+')
             red_out = re.compile(
-                '/dev/out/red-\d+, opaque:local\|>[\da-h]+-\d+-\d+')
+                '/dev/out/red-\d+, opaque:local\|>[^-]+-\d+-\d+')
             for i in range(1, mapper_count + 1):
                 req = self.object_request('/v1/a/terasort/log/%d.log' % i)
                 res = req.get_response(prosrv)

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -988,7 +988,7 @@ class ClusterController(ObjectController):
                 node.name_service = 'udp:%s:%d' % (addr, ns_server.port)
             if self.parser.total_count > 1:
                 self.parser.build_connect_string(
-                    node, req.headers.get('x-zerocloud-id', ''))
+                    node, req.headers.get('x-trans-id'))
                 if node.replicate > 1:
                     for i in range(0, node.replicate - 1):
                         node.replicas.append(deepcopy(node))


### PR DESCRIPTION
using cluster-id in opaque network strings was not that convinient as it is hard to track the request that triggers particular network exchange
now the opaque string will use tx.... transaction id from Swift logs
