### PR TITLE
Inline gists in hacking document

### DIFF
--- a/doc/Hacking.md
+++ b/doc/Hacking.md
@@ -106,7 +106,11 @@ We now need to add ZeroCloud to the Swift pipeline.
 
     ```ini
     [pipeline:main]
-    pipeline = catch_errors gatekeeper healthcheck proxy-logging cache container_sync bulk slo dlo ratelimit crossdomain authtoken keystoneauth tempauth tempurl formpost staticweb container-quotas account-quotas proxy-logging proxy-query proxy-server
+    pipeline = catch_errors gatekeeper healthcheck proxy-logging cache
+      container_sync bulk slo dlo ratelimit crossdomain authtoken
+      keystoneauth tempauth tempurl formpost staticweb
+      container-quotas account-quotas proxy-logging proxy-query
+      proxy-server
     ```
 
 Additional ZeroCloud configuration options can be found in

--- a/doc/Hacking.md
+++ b/doc/Hacking.md
@@ -102,7 +102,8 @@ We now need to add ZeroCloud to the Swift pipeline.
     ```
 
     We then insert the filter into the main pipeline. Here we inserted
-    it just before the final `proxy-server` filter:
+    the `proxy-query` filter just before the final `proxy-server`
+    filter:
 
     ```ini
     [pipeline:main]


### PR DESCRIPTION
Instead of referring to external resources, the document is now more
self-contained. I felt that the patches were sufficiently simple that
they were better expressed as editing instructions. The advantage of
plain text editing instructions is that anybody can apply them without
having to know how to use patch(1).
