### PR TITLE
fix tox env incompatibilty

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -226,7 +226,8 @@ class TestProxyQuery(unittest.TestCase):
             proxy_server.Application(None, FakeMemcache(),
                                      logger=debug_logger('proxy-ut'),
                                      account_ring=FakeRing(),
-                                     container_ring=FakeRing())
+                                     container_ring=FakeRing(),
+                                     object_ring=FakeRing())
 
         self.zerovm_mock = None
 


### PR DESCRIPTION
fix tox environment problem introduced by 3e623a22cc1176f866263b8b024ad88aee5a1e23
will need to refix it for Swift 2.x
