### PR TITLE
added another channel `/dev/script`

### DIFF
--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -26,7 +26,8 @@ DEVICE_MAP = {
     'output': ACCESS_RANDOM | ACCESS_WRITABLE,
     'debug': ACCESS_NETWORK,
     'image': ACCESS_CDR,
-    'db': ACCESS_CHECKPOINT
+    'db': ACCESS_CHECKPOINT,
+    'script': ACCESS_RANDOM | ACCESS_READABLE,
 }
 
 TAR_MIMES = ['application/x-tar', 'application/x-gtar', 'application/x-ustar']

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -13,7 +13,8 @@ CHANNEL_TYPE_MAP = {
     'output': 3,
     'debug': 0,
     'image': 3,
-    'sysimage': 3
+    'sysimage': 3,
+    'script': 3
 }
 ENV_ITEM = 'name=%s, value=%s\n'
 STD_DEVICES = ['stdin', 'stdout', 'stderr']
@@ -735,6 +736,9 @@ class ClusterConfigParser(object):
         for node in self.node_list:
             if node.attach == 'default':
                 top_channel = node.channels[0]
+                if top_channel.device == 'script' \
+                        and len(node.channels) > 1:
+                    top_channel = node.channels[1]
             else:
                 for chan in node.channels:
                     if node.attach == chan.device\


### PR DESCRIPTION
some Python users were unhappy with no dedicated channel for scripts
added `/dev/script` as a dedicated script channel
the default co-location logic was adjusted to not use `script` channel as a co-located object
if you still want it to be co-located for some strange reason you can use `"attach": "script"`

P.S. I'm considering to use `"attach": "none"` as a default behavior for nodes with just a `script` channel
but let's wait and see
