### PR TITLE
produce better error codes

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -2257,7 +2257,7 @@ return json.dumps(con_list)
             req = self.zerovm_request()
             req.body = conf
             res = req.get_response(prosrv)
-            self.assertEqual(res.status_int, 200)
+            self.assertEqual(res.status_int, 400)
             self.assertEqual(res.body, ('Could not resolve channel path: '
                                         'swift://a/%s' % path) * 2)
             self.assertEqual(res.headers['x-nexe-system'], 'sort,sort')

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -711,6 +711,8 @@ class ClusterController(ObjectController):
             if conn.error:
                 conn.nexe_headers['x-nexe-error'] = \
                     conn.error.replace('\n', '')
+                if conn.resp.status_int > final_response.status_int:
+                    final_response.status = conn.resp.status
             else:
                 if is_success(resp.status_int) and not got_nexe_header:
                     # looks like the middleware is not installed


### PR DESCRIPTION
if one of the queries in clustered environment failed, the final response was still "200 OK"
right now the server will choose randomly one of the error codes from clients and return them to user instead of "OK"
correct error messages can still be parsed from `X-Nexe-Error` response header
