### PR TITLE
test: use `send`, not `sendto` on connected socket

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -491,7 +491,7 @@ class TestProxyQuery(unittest.TestCase):
                 bind_data + connect_data
             ns = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             ns.connect(('localhost', int(ns_port)))
-            ns.sendto(request, ('localhost', int(ns_port)))
+            ns.send(request)
             ns_host = ns.getpeername()[0]
             ns_port = ns.getpeername()[1]
             while 1:

--- a/test/unit/zerovm_mock.py
+++ b/test/unit/zerovm_mock.py
@@ -254,7 +254,7 @@ if getattr(mnfst, 'NameServer', None):
     ns_proto, ns_host, ns_port = mnfst.NameServer.split(':')
     ns = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     ns.connect((ns_host, int(ns_port)))
-    ns.sendto(request, (ns_host, int(ns_port)))
+    ns.send(request)
     ns_host = ns.getpeername()[0]
     ns_port = ns.getpeername()[1]
     while 1:


### PR DESCRIPTION
Fixes https://github.com/zerovm/zerocloud/issues/86.

According to the Python docs
(https://docs.python.org/2/library/socket.html#socket.socket.sendto),
you should not use `socket.sendto` if a socket is already connected.

Linux (Ubuntu 12.04) seems to be forgiving of this behavior, but when I
run tests on OSX, I get several `socket.error: [Errno 56] Socket is
already connected` errors in the test suite.

This behavior can be demonstrated with the following Python script:

``` python
import socket

receiver = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
sender = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

addr = ('127.0.0.1', 27000)
receiver.bind(addr)
sender.connect(addr)

num_bytes = sender.send(b'foo')
print('Received: %s' % receiver.recv(num_bytes))

num_bytes = sender.sendto(b'bar', addr)
print('Received: %s' % receiver.recv(num_bytes))
```

On Linux, this works and the received messages are printed.
On OSX, the `sendto` calls raises a `Socket is already connected` error.
