### PR TITLE
Fix pep8 and pyflakes errors in test code

### DIFF
--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -238,6 +238,7 @@ class NullLoggingHandler(logging.Handler):
 
 
 class UnmockTimeModule(object):
+
     """
     Even if a test mocks time.time - you can restore unmolested behavior in a
     another module who imports time directly by monkey patching it's imported
@@ -360,6 +361,7 @@ class FakeLogger(logging.Logger):
 
 
 class DebugLogger(FakeLogger):
+
     """A simple stdout logging version of FakeLogger"""
 
     def __init__(self, *args, **kwargs):
@@ -419,6 +421,7 @@ if config_true_value(get_config('unit_test').get('fake_syslog', 'False')):
 
 
 class MockTrue(object):
+
     """
     Instances of MockTrue evaluate like True
     Any attr accessed on an instance of MockTrue will return a MockTrue
@@ -622,7 +625,7 @@ def create_random_numbers(max_num, proto='pickle'):
         randindex1 = random.randrange(max_num)
         randindex2 = random.randrange(max_num)
         numlist[randindex1], numlist[randindex2] =\
-        numlist[randindex2], numlist[randindex1]
+            numlist[randindex2], numlist[randindex1]
     if proto == 'binary':
         return struct.pack('%sI' % len(numlist), *numlist)
     else:
@@ -630,7 +633,7 @@ def create_random_numbers(max_num, proto='pickle'):
 
 
 def get_sorted_numbers(min_num=0, max_num=10, proto='pickle'):
-    numlist = [i for i in range(min_num,max_num)]
+    numlist = [i for i in range(min_num, max_num)]
     if proto == 'binary':
         return struct.pack('%sI' % len(numlist), *numlist)
     else:

--- a/test/unit/test_containerquery.py
+++ b/test/unit/test_containerquery.py
@@ -23,6 +23,7 @@ except ImportError:
 
 
 class FakeApp(ContainerController):
+
     def __init__(self, conf):
         ContainerController.__init__(self, conf)
         self.bytes_per_sync = 1
@@ -48,7 +49,7 @@ class TestContainerQuery(unittest.TestCase):
                      'zerovm_sysimage_devices':
                          'sysimage1 /opt/zerovm/sysimage1 '
                          'sysimage2 /opt/zerovm/sysimage2'
-        }
+                     }
         self.cont_controller = FakeApp(self.conf)
         self.app = objectquery.ObjectQueryMiddleware(self.cont_controller,
                                                      self.conf,

--- a/test/unit/test_objectquery.py
+++ b/test/unit/test_objectquery.py
@@ -353,9 +353,6 @@ return resp + out
             self.assertEqual(resp.headers['x-nexe-status'], 'ok.')
             self.assertEqual(resp.headers['x-nexe-validation'], '0')
             self.assertEqual(resp.headers['x-nexe-system'], 'sort')
-            timestamp = normalize_timestamp(time())
-            # self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
-            #     math.floor(float(timestamp)))
             self.assertEquals(
                 resp.headers['content-type'], 'application/x-gtar')
             self.assertEqual(names[0], 'sysmap')

--- a/test/unit/test_objectquery.py
+++ b/test/unit/test_objectquery.py
@@ -21,6 +21,7 @@ from swift.common.utils import mkdirs, normalize_timestamp, get_logger
 from swift.obj.server import ObjectController
 from test.unit import FakeLogger, create_random_numbers, get_sorted_numbers, \
     create_tar
+from test.unit import trim
 
 from test_proxyquery import ZEROVM_DEFAULT_MOCK
 from zerocloud.common import ZvmNode, ACCESS_READABLE, ACCESS_WRITABLE, \
@@ -321,7 +322,7 @@ class TestObjectQuery(unittest.TestCase):
             'stdout', ACCESS_WRITABLE, content_type='message/http')
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
-        nexefile = StringIO(r'''
+        nexefile = StringIO(trim(r'''
 resp = '\n'.join([
     'HTTP/1.1 200 OK',
     'Content-Type: application/json',
@@ -331,7 +332,7 @@ resp = '\n'.join([
     ])
 out = str(sorted(id))
 return resp + out
-'''[1:-1])
+'''))
         with create_tar({'boot': nexefile, 'sysmap': sysmap}) as tar:
             length = os.path.getsize(tar)
             req.body_file = Input(open(tar, 'rb'), length)
@@ -375,7 +376,7 @@ return resp + out
             'stdout', ACCESS_WRITABLE, content_type='message/cgi')
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
-        nexefile = StringIO(r'''
+        nexefile = StringIO(trim(r'''
 resp = '\n'.join([
     'Content-Type: application/json',
     'X-Object-Meta-Key1: value1',
@@ -384,7 +385,7 @@ resp = '\n'.join([
     ])
 out = str(sorted(id))
 return resp + out
-'''[1:-1])
+'''))
         with create_tar({'boot': nexefile, 'sysmap': sysmap}) as tar:
             length = os.path.getsize(tar)
             req.body_file = Input(open(tar, 'rb'), length)
@@ -431,11 +432,11 @@ return resp + out
             'stdout', ACCESS_WRITABLE, content_type='message/http')
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
-        nexefile = StringIO('''
+        nexefile = StringIO(trim('''
 resp = '\\n'.join(['Status: 200 OK', 'Content-Type: application/json', '', ''])
 out = str(sorted(id))
 return resp + out
-'''[1:-1])
+'''))
         with create_tar({'boot': nexefile, 'sysmap': sysmap}) as tar:
             length = os.path.getsize(tar)
             req.body_file = Input(open(tar, 'rb'), length)

--- a/test/unit/test_objectquery.py
+++ b/test/unit/test_objectquery.py
@@ -51,10 +51,11 @@ class FakeLoggingHandler(logging.Handler):
             'warning': [],
             'error': [],
             'critical': [],
-            }
+        }
 
 
 class FakeApp(ObjectController):
+
     def __init__(self, conf):
         ObjectController.__init__(self, conf)
         self.bytes_per_sync = 1
@@ -67,6 +68,7 @@ class FakeApp(ObjectController):
 
 
 class OsMock():
+
     def __init__(self):
         self.closed = False
         self.unlinked = False
@@ -98,13 +100,16 @@ class TestObjectQuery(unittest.TestCase):
         self.testdir = \
             os.path.join(mkdtemp(), 'tmp_test_object_server_ObjectController')
         mkdirs(os.path.join(self.testdir, 'sda1', 'tmp'))
-        self.conf = {'devices': self.testdir,
-                     'mount_check': 'false',
-                     'disable_fallocate': 'true',
-                     'zerovm_sysimage_devices': 'sysimage1 /opt/zerovm/sysimage1 sysimage2 /opt/zerovm/sysimage2'
+        self.conf = {
+            'devices': self.testdir,
+            'mount_check': 'false',
+            'disable_fallocate': 'true',
+            'zerovm_sysimage_devices': ('sysimage1 /opt/zerovm/sysimage1 '
+                                        'sysimage2 /opt/zerovm/sysimage2')
         }
         self.obj_controller = FakeApp(self.conf)
-        self.app = objectquery.ObjectQueryMiddleware(self.obj_controller, self.conf, logger=FakeLogger())
+        self.app = objectquery.ObjectQueryMiddleware(
+            self.obj_controller, self.conf, logger=FakeLogger())
         self.app.zerovm_maxoutput = 1024 * 1024 * 10
         self.zerovm_mock = None
         self.uid_generator = Zuid()
@@ -187,16 +192,20 @@ class TestObjectQuery(unittest.TestCase):
         orig_exe = self.app.zerovm_exename
         orig_sysimages = self.app.zerovm_sysimage_devices
         try:
-            self.app.zerovm_sysimage_devices['python-image'] = '/media/40G/zerovm-samples/zshell/zpython2/python.tar'
+            self.app.zerovm_sysimage_devices['python-image'] = (
+                '/media/40G/zerovm-samples/zshell/zpython2/python.tar'
+            )
             self.setup_zerovm_query()
             self.app.zerovm_exename = ['/opt/zerovm/bin/zerovm']
             req = self.zerovm_free_request()
             req.headers['x-zerovm-daemon'] = 'asdf'
-            conf = ZvmNode(1, 'python', parse_location('file://python-image:python'), args='hello.py')
+            conf = ZvmNode(1, 'python', parse_location(
+                'file://python-image:python'), args='hello.py')
             conf.add_new_channel('stdout', ACCESS_WRITABLE)
-            conf.add_new_channel('python-image', ACCESS_READABLE | ACCESS_RANDOM)
+            conf.add_new_channel(
+                'python-image', ACCESS_READABLE | ACCESS_RANDOM)
             conf.add_new_channel('image', ACCESS_CDR, removable='yes')
-            #print json.dumps(conf, cls=NodeEncoder, indent=2)
+            # print json.dumps(conf, cls=NodeEncoder, indent=2)
             conf = json.dumps(conf, cls=NodeEncoder)
             sysmap = StringIO(conf)
             image = open('/home/kit/python-script.tar', 'rb')
@@ -204,7 +213,8 @@ class TestObjectQuery(unittest.TestCase):
                 length = os.path.getsize(tar)
                 req.body_file = Input(open(tar, 'rb'), length)
                 resp = self.app.zerovm_query(req)
-                print ['x-zerovm-daemon', resp.headers.get('x-zerovm-daemon', '---')]
+                print ['x-zerovm-daemon', resp.headers.get('x-zerovm-daemon',
+                                                           '---')]
                 print ['x-nexe-cdr-line', resp.headers['x-nexe-cdr-line']]
                 if resp.content_type in TAR_MIMES:
                     fd, name = mkstemp()
@@ -227,7 +237,8 @@ class TestObjectQuery(unittest.TestCase):
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -236,7 +247,6 @@ class TestObjectQuery(unittest.TestCase):
             req.body_file = Input(open(tar, 'rb'), length)
             req.content_length = length
             resp = self.app.zerovm_query(req)
-            #resp = req.get_response(self.app)
             fd, name = mkstemp()
             for chunk in resp.app_iter:
                 os.write(fd, chunk)
@@ -256,9 +266,10 @@ class TestObjectQuery(unittest.TestCase):
             self.assertEqual(resp.headers['x-nexe-system'], 'sort')
             timestamp = normalize_timestamp(time())
             self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
-                math.floor(float(timestamp)))
-            self.assertEquals(resp.headers['content-type'], 'application/x-gtar')
-            #self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
+                             math.floor(float(timestamp)))
+            self.assertEquals(
+                resp.headers['content-type'], 'application/x-gtar')
+            # self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
             #    'Zerovm CDR: 0 0 0 0 1 46 2 56 0 0 0 0')
 
     def test_QUERY_sort_textout(self):
@@ -266,7 +277,8 @@ class TestObjectQuery(unittest.TestCase):
         req = self.zerovm_object_request()
         nexefile = StringIO('return str(sorted(id))')
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -275,7 +287,6 @@ class TestObjectQuery(unittest.TestCase):
             req.body_file = Input(open(tar, 'rb'), length)
             req.content_length = length
             resp = self.app.zerovm_query(req)
-            #resp = req.get_response(self.app)
             fd, name = mkstemp()
             for chunk in resp.app_iter:
                 os.write(fd, chunk)
@@ -286,7 +297,6 @@ class TestObjectQuery(unittest.TestCase):
             members = tar.getmembers()
             self.assertIn('stdout', names)
             self.assertEqual(names[-1], 'stdout')
-            #self.assertEqual(members[-1].size, len(self._sortednumbers))
             file = tar.extractfile(members[-1])
             self.assertEqual(file.read(), '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]')
             self.assertEqual(resp.headers['x-nexe-retcode'], '0')
@@ -295,17 +305,20 @@ class TestObjectQuery(unittest.TestCase):
             self.assertEqual(resp.headers['x-nexe-system'], 'sort')
             timestamp = normalize_timestamp(time())
             self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
-                math.floor(float(timestamp)))
-            self.assertEquals(resp.headers['content-type'], 'application/x-gtar')
-            #self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
+                             math.floor(float(timestamp)))
+            self.assertEquals(
+                resp.headers['content-type'], 'application/x-gtar')
+            # self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
             #    'Zerovm CDR: 0 0 0 0 1 46 2 40 0 0 0 0')
 
     def test_QUERY_http_message(self):
         self.setup_zerovm_query()
         req = self.zerovm_object_request()
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
-        conf.add_new_channel('stdout', ACCESS_WRITABLE, content_type='message/http')
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdout', ACCESS_WRITABLE, content_type='message/http')
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
         nexefile = StringIO(r'''
@@ -324,7 +337,6 @@ return resp + out
             req.body_file = Input(open(tar, 'rb'), length)
             req.content_length = length
             resp = self.app.zerovm_query(req)
-            #resp = req.get_response(self.app)
             fd, name = mkstemp()
             for chunk in resp.app_iter:
                 os.write(fd, chunk)
@@ -344,7 +356,8 @@ return resp + out
             timestamp = normalize_timestamp(time())
             # self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
             #     math.floor(float(timestamp)))
-            self.assertEquals(resp.headers['content-type'], 'application/x-gtar')
+            self.assertEquals(
+                resp.headers['content-type'], 'application/x-gtar')
             self.assertEqual(names[0], 'sysmap')
             file = tar.extractfile(members[0])
             config = json.load(file)
@@ -359,8 +372,10 @@ return resp + out
         self.setup_zerovm_query()
         req = self.zerovm_object_request()
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
-        conf.add_new_channel('stdout', ACCESS_WRITABLE, content_type='message/cgi')
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdout', ACCESS_WRITABLE, content_type='message/cgi')
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
         nexefile = StringIO(r'''
@@ -378,7 +393,6 @@ return resp + out
             req.body_file = Input(open(tar, 'rb'), length)
             req.content_length = length
             resp = self.app.zerovm_query(req)
-            #resp = req.get_response(self.app)
             fd, name = mkstemp()
             for chunk in resp.app_iter:
                 os.write(fd, chunk)
@@ -397,8 +411,9 @@ return resp + out
             self.assertEqual(resp.headers['x-nexe-system'], 'sort')
             timestamp = normalize_timestamp(time())
             self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
-                math.floor(float(timestamp)))
-            self.assertEquals(resp.headers['content-type'], 'application/x-gtar')
+                             math.floor(float(timestamp)))
+            self.assertEquals(
+                resp.headers['content-type'], 'application/x-gtar')
             self.assertEqual(names[0], 'sysmap')
             file = tar.extractfile(members[0])
             config = json.load(file)
@@ -407,14 +422,16 @@ return resp + out
                 'application/json')
             self.assertEqual(
                 config['channels'][1]['meta'],
-                { 'key1': 'value1', 'key2': 'value2' })
+                {'key1': 'value1', 'key2': 'value2'})
 
     def test_QUERY_invalid_http_message(self):
         self.setup_zerovm_query()
         req = self.zerovm_object_request()
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
-        conf.add_new_channel('stdout', ACCESS_WRITABLE, content_type='message/http')
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdout', ACCESS_WRITABLE, content_type='message/http')
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
         nexefile = StringIO('''
@@ -427,7 +444,6 @@ return resp + out
             req.body_file = Input(open(tar, 'rb'), length)
             req.content_length = length
             resp = self.app.zerovm_query(req)
-            #resp = req.get_response(self.app)
             fd, name = mkstemp()
             for chunk in resp.app_iter:
                 os.write(fd, chunk)
@@ -449,19 +465,22 @@ return resp + out
             self.assertEqual(resp.headers['x-nexe-system'], 'sort')
             timestamp = normalize_timestamp(time())
             self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
-                math.floor(float(timestamp)))
-            self.assertEqual(resp.headers['content-type'], 'application/x-gtar')
+                             math.floor(float(timestamp)))
+            self.assertEqual(
+                resp.headers['content-type'], 'application/x-gtar')
             self.assertEqual(names[0], 'sysmap')
             file = tar.extractfile(members[0])
             config = json.load(file)
-            self.assertEqual(config['channels'][1]['content_type'], 'message/http')
+            self.assertEqual(
+                config['channels'][1]['content_type'], 'message/http')
 
     def test_QUERY_invalid_nexe(self):
         self.setup_zerovm_query()
         req = self.zerovm_object_request()
         nexefile = StringIO('INVALID')
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -470,7 +489,6 @@ return resp + out
             req.body_file = Input(open(tar, 'rb'), length)
             req.content_length = length
             resp = self.app.zerovm_query(req)
-            #resp = req.get_response(self.app)
             fd, name = mkstemp()
             for chunk in resp.app_iter:
                 os.write(fd, chunk)
@@ -490,9 +508,10 @@ return resp + out
             self.assertEqual(resp.headers['x-nexe-system'], 'sort')
             timestamp = normalize_timestamp(time())
             self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
-                math.floor(float(timestamp)))
-            self.assertEqual(resp.headers['content-type'], 'application/x-gtar')
-            #self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
+                             math.floor(float(timestamp)))
+            self.assertEqual(
+                resp.headers['content-type'], 'application/x-gtar')
+            # self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
             #    'Zerovm CDR: 0 0 0 0 0 0 0 0 0 0 0 0')
 
     def test_QUERY_freenode(self):
@@ -510,7 +529,6 @@ return resp + out
             req.body_file = Input(open(tar, 'rb'), length)
             req.content_length = length
             resp = self.app.zerovm_query(req)
-            #resp = req.get_response(self.app)
             fd, name = mkstemp()
             for chunk in resp.app_iter:
                 os.write(fd, chunk)
@@ -530,9 +548,10 @@ return resp + out
             self.assertEqual(resp.headers['x-nexe-system'], 'sort')
             timestamp = normalize_timestamp(time())
             self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
-                math.floor(float(timestamp)))
-            self.assertEqual(resp.headers['content-type'], 'application/x-gtar')
-            #self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
+                             math.floor(float(timestamp)))
+            self.assertEqual(
+                resp.headers['content-type'], 'application/x-gtar')
+            # self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
             #    'Zerovm CDR: 0 0 0 0 1 0 2 13 0 0 0 0')
 
     def test_QUERY_write_only(self):
@@ -543,19 +562,23 @@ return resp + out
         meta = {'key1': 'value1',
                 'key2': 'value2'}
         content_type = 'application/x-pickle'
-        conf.add_new_channel('stdout', ACCESS_WRITABLE, parse_location('swift://a/c/out'),
-                         meta_data=meta,
-                         content_type=content_type)
+        conf.add_new_channel('stdout',
+                             ACCESS_WRITABLE,
+                             parse_location('swift://a/c/out'),
+                             meta_data=meta,
+                             content_type=content_type)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
         timestamp = normalize_timestamp(time())
         req = Request.blank('/sda1/p/a/c/out',
                             environ={'REQUEST_METHOD': 'POST'},
-                            headers={'Content-Type': 'application/x-gtar',
-                                     'x-zerovm-execute': '1.0',
-                                     'x-zerocloud-id': self.uid_generator.get(),
-                                     'x-timestamp': timestamp,
-                                     'x-zerovm-access': 'PUT'})
+                            headers={
+                                'Content-Type': 'application/x-gtar',
+                                'x-zerovm-execute': '1.0',
+                                'x-zerocloud-id': self.uid_generator.get(),
+                                'x-timestamp': timestamp,
+                                'x-zerovm-access': 'PUT'
+                            })
         with create_tar({'boot': nexefile, 'sysmap': sysmap}) as tar:
             length = os.path.getsize(tar)
             req.body_file = Input(open(tar, 'rb'), length)
@@ -587,20 +610,24 @@ return resp + out
         meta = {'key1': 'value1',
                 'key2': 'value2'}
         content_type = 'application/x-pickle'
-        conf.add_new_channel('stdout', ACCESS_WRITABLE, parse_location('swift://a/c/out'),
-                         meta_data=meta,
-                         content_type=content_type)
+        conf.add_new_channel('stdout',
+                             ACCESS_WRITABLE,
+                             parse_location('swift://a/c/out'),
+                             meta_data=meta,
+                             content_type=content_type)
         conf.add_new_channel('stderr', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
         timestamp = normalize_timestamp(time())
         req = Request.blank('/sda1/p/a/c/out',
                             environ={'REQUEST_METHOD': 'POST'},
-                            headers={'Content-Type': 'application/x-gtar',
-                                     'x-zerovm-execute': '1.0',
-                                     'x-zerocloud-id': self.uid_generator.get(),
-                                     'x-timestamp': timestamp,
-                                     'x-zerovm-access': 'PUT'})
+                            headers={
+                                'Content-Type': 'application/x-gtar',
+                                'x-zerovm-execute': '1.0',
+                                'x-zerocloud-id': self.uid_generator.get(),
+                                'x-timestamp': timestamp,
+                                'x-zerovm-access': 'PUT'
+                            })
         with create_tar({'boot': nexefile, 'sysmap': sysmap}) as tar:
             length = os.path.getsize(tar)
             req.body_file = Input(open(tar, 'rb'), length)
@@ -650,7 +677,6 @@ return resp + out
             req.body_file = Input(open(tar, 'rb'), length)
             req.content_length = length
             resp = self.app.zerovm_query(req)
-            #resp = req.get_response(self.app)
             fd, name = mkstemp()
             for chunk in resp.app_iter:
                 os.write(fd, chunk)
@@ -665,7 +691,6 @@ return resp + out
             file = tar.extractfile(members[-1])
             self.assertEqual(file.read(), self._emptyresult)
 
-        #del self.app.zerovm_maxoutput
         del self.app.parser_config['limits']['wbytes']
         self.setup_zerovm_query()
         req = self.zerovm_free_request()
@@ -708,7 +733,8 @@ return resp + out
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf.args = 'aaa bbb'
         conf.env = {'KEY_A': 'value_a', 'KEY_B': 'value_b'}
@@ -726,8 +752,10 @@ return resp + out
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('input', ACCESS_READABLE, parse_location('swift://a/c/o'))
-        conf.add_new_channel('output', ACCESS_WRITABLE, parse_location('swift://a/c/o2'))
+        conf.add_new_channel(
+            'input', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'output', ACCESS_WRITABLE, parse_location('swift://a/c/o2'))
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
         with create_tar({'boot': nexefile, 'sysmap': sysmap}) as tar:
@@ -742,8 +770,10 @@ return resp + out
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
-        conf.add_new_channel('stdout', ACCESS_WRITABLE, parse_location('swift://a/c/o2'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdout', ACCESS_WRITABLE, parse_location('swift://a/c/o2'))
         conf.add_new_channel('stderr', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -775,7 +805,8 @@ return resp + out
     def test_QUERY_logger(self):
         # check logger assignment
         logger = get_logger({}, log_route='obj-query-test')
-        self.app = objectquery.ObjectQueryMiddleware(self.obj_controller, self.conf, logger)
+        self.app = objectquery.ObjectQueryMiddleware(
+            self.obj_controller, self.conf, logger)
         self.assertIs(logger, self.app.logger)
 
     def test_QUERY_object_not_exists(self):
@@ -783,7 +814,8 @@ return resp + out
         req = self.zerovm_object_request()
         nexefile = StringIO('SCRIPT')
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -798,13 +830,16 @@ return resp + out
         # check if just querying container fails
         req = Request.blank('/sda1/p/a/c',
                             environ={'REQUEST_METHOD': 'POST'},
-                            headers={'x-zerovm-execute': '1.0',
-                                     'x-zerocloud-id': self.uid_generator.get()})
+                            headers={
+                                'x-zerovm-execute': '1.0',
+                                'x-zerocloud-id': self.uid_generator.get()
+                            })
         resp = req.get_response(self.app)
         self.assertEquals(resp.status_int, 400)
 
     def test_QUERY_max_upload_time(self):
         class SlowBody():
+
             def __init__(self, body):
                 self.body = body
 
@@ -815,7 +850,8 @@ return resp + out
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -871,7 +907,8 @@ return resp + out
         req = Request.blank('/sda1/p/a/c/o'.encode('utf-16'),
                             environ={'REQUEST_METHOD': 'POST'},
                             headers={'Content-Type': 'application/x-gtar',
-                                     'x-zerovm-execute': '1.0', 'x-account-name': 'a'})
+                                     'x-zerovm-execute': '1.0',
+                                     'x-account-name': 'a'})
         req.body = 'SCRIPT'
         resp = req.get_response(self.app)
         self.assertEquals(resp.status_int, 412)
@@ -887,7 +924,9 @@ return resp + out
         self.assert_('Traceback' in resp.body)
 
     def test_QUERY_script_invalid_etag(self):
-        raise SkipTest # we cannot etag the tar stream because we mangle it while transferring, on the fly
+        # we cannot etag the tar stream because we mangle it while
+        # transferring, on the fly
+        raise SkipTest
         self.setup_zerovm_query()
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
@@ -914,6 +953,7 @@ return resp + out
 
     def test_QUERY_short_body(self):
         class ShortBody():
+
             def __init__(self):
                 self.sent = False
 
@@ -925,17 +965,23 @@ return resp + out
 
         self.setup_zerovm_query()
         req = Request.blank('/sda1/p/a/c/o',
-                            environ={'REQUEST_METHOD': 'POST', 'wsgi.input': Input(ShortBody(), 4)},
-                            headers={'X-Timestamp': normalize_timestamp(time()),
-                                     'x-zerovm-execute': '1.0',
-                                     'x-zerocloud-id': self.uid_generator.get(),
-                                     'Content-Length': '4',
-                                     'Content-Type': 'application/x-gtar'})
+                            environ={
+                                'REQUEST_METHOD': 'POST',
+                                'wsgi.input': Input(ShortBody(), 4)
+                            },
+                            headers={
+                                'X-Timestamp': normalize_timestamp(time()),
+                                'x-zerovm-execute': '1.0',
+                                'x-zerocloud-id': self.uid_generator.get(),
+                                'Content-Length': '4',
+                                'Content-Type': 'application/x-gtar'
+                            })
         resp = req.get_response(self.app)
         self.assertEquals(resp.status_int, 499)
 
     def test_QUERY_long_body(self):
         class LongBody():
+
             def __init__(self):
                 self.sent = False
 
@@ -947,18 +993,23 @@ return resp + out
 
         self.setup_zerovm_query()
         req = Request.blank('/sda1/p/a/c/o',
-                            environ={'REQUEST_METHOD': 'POST', 'wsgi.input': Input(LongBody(), 2)},
-                            headers={'X-Timestamp': normalize_timestamp(time()),
-                                     'x-zerovm-execute': '1.0',
-                                     'x-zerocloud-id': self.uid_generator.get(),
-                                     'Content-Length': '2',
-                                     'Content-Type': 'application/x-gtar'})
+                            environ={
+                                'REQUEST_METHOD': 'POST',
+                                'wsgi.input': Input(LongBody(), 2)
+                            },
+                            headers={
+                                'X-Timestamp': normalize_timestamp(time()),
+                                'x-zerovm-execute': '1.0',
+                                'x-zerocloud-id': self.uid_generator.get(),
+                                'Content-Length': '2',
+                                'Content-Type': 'application/x-gtar'
+                            })
         resp = req.get_response(self.app)
         self.assertEquals(resp.status_int, 499)
 
     def test_QUERY_zerovm_stderr(self):
         self.setup_zerovm_query(
-r'''
+            r'''
 import sys
 sys.stderr.write('some shit happened\n')
 ''')
@@ -966,7 +1017,8 @@ sys.stderr.write('some shit happened\n')
 
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -976,10 +1028,12 @@ sys.stderr.write('some shit happened\n')
             req.content_length = length
             resp = self.app.zerovm_query(req)
             self.assertEquals(resp.status_int, 500)
-            self.assertIn('ERROR OBJ.QUERY retcode=OK,  zerovm_stdout=some shit happened', resp.body)
+            self.assertIn('ERROR OBJ.QUERY retcode=OK,  '
+                          'zerovm_stdout=some shit happened',
+                          resp.body)
 
         self.setup_zerovm_query(
-r'''
+            r'''
 import sys
 import time
 sys.stdout.write('0\n\nok.\n')
@@ -989,7 +1043,8 @@ for i in range(20):
 ''')
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -1002,7 +1057,7 @@ for i in range(20):
             self.assertIn('ERROR OBJ.QUERY retcode=Output too long', resp.body)
 
         self.setup_zerovm_query(
-r'''
+            r'''
 import sys, time, signal
 signal.signal(signal.SIGTERM, signal.SIG_IGN)
 time.sleep(0.9)
@@ -1011,7 +1066,8 @@ sys.stderr.write(''.zfill(4096*20))
 ''')
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -1024,20 +1080,22 @@ sys.stderr.write(''.zfill(4096*20))
                 req.content_length = length
                 resp = self.app.zerovm_query(req)
                 self.assertEqual(resp.status_int, 500)
-                self.assertIn('ERROR OBJ.QUERY retcode=Output too long', resp.body)
+                self.assertIn(
+                    'ERROR OBJ.QUERY retcode=Output too long', resp.body)
             finally:
                 self.app.parser_config['manifest']['Timeout'] = orig_timeout
 
     def test_QUERY_zerovm_term_timeouts(self):
         self.setup_zerovm_query(
-r'''
+            r'''
 from time import sleep
 sleep(10)
 ''')
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -1056,7 +1114,7 @@ sleep(10)
 
     def test_QUERY_zerovm_kill_timeouts(self):
         self.setup_zerovm_query(
-r'''
+            r'''
 import signal, time
 signal.signal(signal.SIGTERM, signal.SIG_IGN)
 time.sleep(10)
@@ -1064,7 +1122,8 @@ time.sleep(10)
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -1109,7 +1168,8 @@ time.sleep(10)
                         req[i].content_length = length
                     size = int(maxreq_factor * pool_factor * 5)
                     queue = int(maxreq_factor * queue_factor * 5)
-                    self.app.zerovm_thread_pools['default'] = WaitPool(size, queue)
+                    self.app.zerovm_thread_pools[
+                        'default'] = WaitPool(size, queue)
                     spil_over = size + queue
                     for i in r:
                         t[i] = pool.spawn(self.app.zerovm_query, req[i])
@@ -1117,11 +1177,11 @@ time.sleep(10)
                     resp = copy(r)
                     for i in r[:spil_over]:
                         resp[i] = t[i].wait()
-                        #print 'expecting ok #%s: %s' % (i, resp[i])
+                        # print 'expecting ok #%s: %s' % (i, resp[i])
                         self.assertEqual(resp[i].status_int, 200)
                     for i in r[spil_over:]:
                         resp[i] = t[i].wait()
-                        #print 'expecting fail #%s: %s' % (i, resp[i])
+                        # print 'expecting fail #%s: %s' % (i, resp[i])
                         self.assertEqual(resp[i].status_int, 503)
                         self.assertEqual(resp[i].body, 'Slot not available')
 
@@ -1147,13 +1207,16 @@ time.sleep(10)
 
             nexefile = StringIO(self._nexescript)
             conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-            conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+            conf.add_new_channel(
+                'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
             conf.add_new_channel('stdout', ACCESS_WRITABLE)
             conf = json.dumps(conf, cls=NodeEncoder)
             sysmap = StringIO(conf)
             with create_tar({'boot': nexefile, 'sysmap': sysmap}) as tar:
-                self.create_object(create_random_numbers(os.path.getsize(tar) + 2))
-                self.app.parser_config['limits']['rbytes'] = os.path.getsize(tar) + 1
+                self.create_object(
+                    create_random_numbers(os.path.getsize(tar) + 2))
+                self.app.parser_config['limits'][
+                    'rbytes'] = os.path.getsize(tar) + 1
                 req = self.zerovm_object_request()
                 length = os.path.getsize(tar)
                 req.body_file = Input(open(tar, 'rb'), length)
@@ -1173,7 +1236,8 @@ time.sleep(10)
             req = self.zerovm_object_request()
             nexefile = StringIO(self._nexescript)
             conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-            conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+            conf.add_new_channel(
+                'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
             conf.add_new_channel('stdout', ACCESS_WRITABLE)
             conf = json.dumps(conf, cls=NodeEncoder)
             sysmap = StringIO(conf)
@@ -1220,7 +1284,8 @@ time.sleep(10)
                      'open(mnfst.channels["/dev/nvram"]["path"]).read()' \
                      % dev
             nexefile = StringIO(script)
-            conf = ZvmNode(1, 'sysimage-test', parse_location('swift://a/c/exe'))
+            conf = ZvmNode(
+                1, 'sysimage-test', parse_location('swift://a/c/exe'))
             conf.add_new_channel(dev, ACCESS_CDR)
             conf.add_new_channel('stdout', ACCESS_WRITABLE)
             conf = json.dumps(conf, cls=NodeEncoder)
@@ -1241,29 +1306,34 @@ time.sleep(10)
                 self.assertIn('stdout', names)
                 self.assertEqual(names[-1], 'stdout')
                 file = tar.extractfile(members[-1])
-                out = '%s\n'\
-                      '[fstab]\n'\
-                      'channel=/dev/%s, mountpoint=/, access=ro, removable=no\n'\
-                      '[args]\n'\
-                      'args = sysimage-test\n' % (path, dev)
+                out = (
+                    '%s\n'
+                    '[fstab]\n'
+                    'channel=/dev/%s, mountpoint=/, access=ro, removable=no\n'
+                    '[args]\n'
+                    'args = sysimage-test\n' % (path, dev)
+                )
                 self.assertEqual(file.read(), out)
                 self.assertEqual(resp.headers['x-nexe-retcode'], '0')
                 self.assertEqual(resp.headers['x-nexe-status'], 'ok.')
                 self.assertEqual(resp.headers['x-nexe-validation'], '0')
-                self.assertEqual(resp.headers['x-nexe-system'], 'sysimage-test')
+                self.assertEqual(
+                    resp.headers['x-nexe-system'], 'sysimage-test')
 
     def test_QUERY_use_image_file(self):
         self.setup_zerovm_query()
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', 'file://usr/bin/sort')
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf.add_new_channel('image', ACCESS_CDR)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
         with create_tar({'usr/bin/sort': nexefile}) as image_tar:
-            with create_tar({'image': open(image_tar, 'rb'), 'sysmap': sysmap}) as tar:
+            with create_tar({'image': open(image_tar, 'rb'),
+                             'sysmap': sysmap}) as tar:
                 length = os.path.getsize(tar)
                 req.body_file = Input(open(tar, 'rb'), length)
                 req.content_length = length
@@ -1287,10 +1357,13 @@ time.sleep(10)
                 self.assertEqual(resp.headers['x-nexe-validation'], '0')
                 self.assertEqual(resp.headers['x-nexe-system'], 'sort')
                 timestamp = normalize_timestamp(time())
-                self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
-                    math.floor(float(timestamp)))
-                self.assertEquals(resp.headers['content-type'], 'application/x-gtar')
-                #self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
+                self.assertEqual(
+                    math.floor(float(resp.headers['X-Timestamp'])),
+                    math.floor(float(timestamp))
+                )
+                self.assertEquals(
+                    resp.headers['content-type'], 'application/x-gtar')
+                # self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
                 #    'Zerovm CDR: 0 0 0 0 1 46 2 56 0 0 0 0')
 
     def test_QUERY_use_gzipped_image(self):
@@ -1298,7 +1371,8 @@ time.sleep(10)
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', 'file://usr/bin/sort')
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf.add_new_channel('image', ACCESS_CDR)
         conf = json.dumps(conf, cls=NodeEncoder)
@@ -1313,7 +1387,7 @@ time.sleep(10)
                 gz.close()
                 t.close()
                 with create_tar({'image.gz': open(image_tar_gz, 'rb'),
-                                      'sysmap': sysmap}) as tar:
+                                 'sysmap': sysmap}) as tar:
                     length = os.path.getsize(tar)
                     req.body_file = Input(open(tar, 'rb'), length)
                     req.content_length = length
@@ -1323,13 +1397,15 @@ time.sleep(10)
                     for chunk in resp.app_iter:
                         os.write(fd, chunk)
                     os.close(fd)
-                    self.assertEqual(os.path.getsize(name), resp.content_length)
+                    self.assertEqual(
+                        os.path.getsize(name), resp.content_length)
                     tar = tarfile.open(name)
                     names = tar.getnames()
                     members = tar.getmembers()
                     self.assertIn('stdout', names)
                     self.assertEqual(names[-1], 'stdout')
-                    self.assertEqual(members[-1].size, len(self._sortednumbers))
+                    self.assertEqual(
+                        members[-1].size, len(self._sortednumbers))
                     file = tar.extractfile(members[-1])
                     self.assertEqual(file.read(), self._sortednumbers)
                     self.assertEqual(resp.headers['x-nexe-retcode'], '0')
@@ -1337,27 +1413,32 @@ time.sleep(10)
                     self.assertEqual(resp.headers['x-nexe-validation'], '0')
                     self.assertEqual(resp.headers['x-nexe-system'], 'sort')
                     timestamp = normalize_timestamp(time())
-                    self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
-                                     math.floor(float(timestamp)))
-                    self.assertEquals(resp.headers['content-type'], 'application/x-gtar')
+                    self.assertEqual(
+                        math.floor(float(resp.headers['X-Timestamp'])),
+                        math.floor(float(timestamp))
+                    )
+                    self.assertEquals(
+                        resp.headers['content-type'], 'application/x-gtar')
             finally:
                 try:
                     os.unlink(image_tar_gz)
                 except OSError:
-                        pass
+                    pass
 
     def test_QUERY_bypass_image_file(self):
         self.setup_zerovm_query()
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf.add_new_channel('image', ACCESS_CDR)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
         with create_tar({'usr/bin/sort': StringIO('bla-bla')}) as image_tar:
-            with create_tar({'image': open(image_tar, 'rb'), 'sysmap': sysmap, 'boot': nexefile}) as tar:
+            with create_tar({'image': open(image_tar, 'rb'),
+                             'sysmap': sysmap, 'boot': nexefile}) as tar:
                 length = os.path.getsize(tar)
                 req.body_file = Input(open(tar, 'rb'), length)
                 req.content_length = length
@@ -1381,10 +1462,13 @@ time.sleep(10)
                 self.assertEqual(resp.headers['x-nexe-validation'], '0')
                 self.assertEqual(resp.headers['x-nexe-system'], 'sort')
                 timestamp = normalize_timestamp(time())
-                self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
-                    math.floor(float(timestamp)))
-                self.assertEquals(resp.headers['content-type'], 'application/x-gtar')
-                #self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
+                self.assertEqual(
+                    math.floor(float(resp.headers['X-Timestamp'])),
+                    math.floor(float(timestamp))
+                )
+                self.assertEquals(
+                    resp.headers['content-type'], 'application/x-gtar')
+                # self.assertEqual(self.app.logger.log_dict['info'][0][0][0],
                 #    'Zerovm CDR: 0 0 0 0 1 46 1 46 0 0 0 0')
 
     def test_QUERY_bad_channel_path(self):
@@ -1402,7 +1486,8 @@ time.sleep(10)
             resp = self.app.zerovm_query(req)
             fd, name = mkstemp()
             self.assertEqual(resp.status_int, 400)
-            self.assertEqual(resp.body, 'Could not resolve channel path: bla-bla')
+            self.assertEqual(
+                resp.body, 'Could not resolve channel path: bla-bla')
 
     def test_QUERY_filter_factory(self):
         app = objectquery.filter_factory(self.conf)(FakeApp(self.conf))
@@ -1412,9 +1497,11 @@ time.sleep(10)
         self.setup_zerovm_query()
         req = Request.blank('/sda1/p/a/c/exe',
                             environ={'REQUEST_METHOD': 'PUT'},
-                            headers={'X-Timestamp': normalize_timestamp(time()),
-                                     'x-zerovm-validate': 'true',
-                                     'Content-Type': 'application/octet-stream'})
+                            headers={
+                                'X-Timestamp': normalize_timestamp(time()),
+                                'x-zerovm-validate': 'true',
+                                'Content-Type': 'application/octet-stream'
+                            })
         req.body = self._nexescript
         resp = req.get_response(self.app)
         self.assertEquals(resp.status_int, 201)
@@ -1429,8 +1516,10 @@ time.sleep(10)
 
         req = Request.blank('/sda1/p/a/c/exe',
                             environ={'REQUEST_METHOD': 'PUT'},
-                            headers={'X-Timestamp': normalize_timestamp(time()),
-                                     'Content-Type': 'application/octet-stream'})
+                            headers={
+                                'X-Timestamp': normalize_timestamp(time()),
+                                'Content-Type': 'application/octet-stream'
+                            })
         req.body = self._nexescript
         resp = req.get_response(self.app)
         self.assertEquals(resp.status_int, 201)
@@ -1445,8 +1534,10 @@ time.sleep(10)
 
         req = Request.blank('/sda1/p/a/c/exe',
                             environ={'REQUEST_METHOD': 'PUT'},
-                            headers={'X-Timestamp': normalize_timestamp(time()),
-                                     'Content-Type': 'application/x-nexe'})
+                            headers={
+                                'X-Timestamp': normalize_timestamp(time()),
+                                'Content-Type': 'application/x-nexe'
+                            })
         req.body = self._nexescript
         resp = req.get_response(self.app)
         self.assertEquals(resp.status_int, 201)
@@ -1454,8 +1545,10 @@ time.sleep(10)
 
         req = Request.blank('/sda1/p/a/c/exe',
                             environ={'REQUEST_METHOD': 'PUT'},
-                            headers={'X-Timestamp': normalize_timestamp(time()),
-                                     'Content-Type': 'application/octet-stream'})
+                            headers={
+                                'X-Timestamp': normalize_timestamp(time()),
+                                'Content-Type': 'application/octet-stream'
+                            })
         req.body = 'INVALID'
         resp = req.get_response(self.app)
         self.assertEquals(resp.status_int, 201)
@@ -1463,9 +1556,11 @@ time.sleep(10)
 
         req = Request.blank('/sda1/p/a/c/exe',
                             environ={'REQUEST_METHOD': 'PUT'},
-                            headers={'X-Timestamp': normalize_timestamp(time()),
-                                     'x-zerovm-validate': 'true',
-                                     'Content-Type': 'application/octet-stream'})
+                            headers={
+                                'X-Timestamp': normalize_timestamp(time()),
+                                'x-zerovm-validate': 'true',
+                                'Content-Type': 'application/octet-stream'
+                            })
         req.body = 'INVALID'
         resp = req.get_response(self.app)
         self.assertEquals(resp.status_int, 201)
@@ -1476,7 +1571,8 @@ time.sleep(10)
         req = self.zerovm_object_request()
         nexefile = StringIO(self._nexescript)
         conf = ZvmNode(1, 'sort', parse_location('swift://a/c/exe'))
-        conf.add_new_channel('stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
+        conf.add_new_channel(
+            'stdin', ACCESS_READABLE, parse_location('swift://a/c/o'))
         conf.add_new_channel('stdout', ACCESS_WRITABLE)
         conf = json.dumps(conf, cls=NodeEncoder)
         sysmap = StringIO(conf)
@@ -1506,7 +1602,8 @@ time.sleep(10)
             timestamp = normalize_timestamp(time())
             self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
                              math.floor(float(timestamp)))
-            self.assertEquals(resp.headers['content-type'], 'application/x-gtar')
+            self.assertEquals(
+                resp.headers['content-type'], 'application/x-gtar')
 
             req.headers['x-zerovm-valid'] = 'false'
             length = os.path.getsize(tar)
@@ -1533,7 +1630,8 @@ time.sleep(10)
             timestamp = normalize_timestamp(time())
             self.assertEqual(math.floor(float(resp.headers['X-Timestamp'])),
                              math.floor(float(timestamp)))
-            self.assertEquals(resp.headers['content-type'], 'application/x-gtar')
+            self.assertEquals(
+                resp.headers['content-type'], 'application/x-gtar')
 
     def test_zerovm_bad_exit_code(self):
 
@@ -1549,11 +1647,11 @@ time.sleep(10)
         with save_zerovm_exename():
             (zfd, zerovm) = mkstemp()
             os.write(zfd,
-r'''
+                     r'''
 from sys import exit
 exit(255)
 '''
-            )
+                     )
             os.close(zfd)
             self.app.zerovm_exename = ['python', zerovm]
             req = self.zerovm_object_request()
@@ -1567,7 +1665,10 @@ exit(255)
                 req.content_length = length
                 resp = self.app.zerovm_query(req)
                 self.assertEquals(resp.status_int, 500)
-                self.assertIn('ERROR OBJ.QUERY retcode=Error,  zerovm_stdout=', resp.body)
+                self.assertIn(
+                    'ERROR OBJ.QUERY retcode=Error,  zerovm_stdout=',
+                    resp.body
+                )
             os.unlink(zerovm)
 
 if __name__ == '__main__':

--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -664,10 +664,9 @@ class TestProxyQuery(unittest.TestCase):
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return 'Test Test'
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         conf = [
             {
@@ -700,10 +699,9 @@ return 'Test Test'
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return 'hello, world'
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/hello.nexe', nexe)
         conf = [
             {
@@ -726,10 +724,9 @@ return 'hello, world'
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return 'hello, world'
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/hello.nexe', nexe)
         conf = [
             {
@@ -754,10 +751,9 @@ return 'hello, world'
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return 'hello, world'
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/hello.nexe', nexe)
         conf = [
             {
@@ -781,8 +777,7 @@ return 'hello, world'
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
 resp = '\n'.join([
     'HTTP/1.1 200 OK',
     'Content-Type: text/html',
@@ -792,7 +787,7 @@ resp = '\n'.join([
     ])
 out = '<html><body>Test this</body></html>'
 return resp + out
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         conf = [
             {
@@ -953,11 +948,10 @@ return resp + out
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
 resp = '<html><body>Test this</body></html>'
 return resp
-'''[1:-1]
+''')
         self.create_object(
             prolis, '/v1/a/c/exe2', nexe, content_type='application/x-nexe')
         req = self.object_request('/v1/a/c/exe2')
@@ -1006,10 +1000,9 @@ return resp
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return [open(mnfst.image['path']).read(), sorted(id)]
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         image = 'This is image file'
         self.create_object(prolis, '/v1/a/c/img', image)
@@ -1037,10 +1030,9 @@ return [open(mnfst.image['path']).read(), sorted(id)]
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return [open(mnfst.image['path']).read(), sorted(id)]
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         image = 'This is image file'
         self.create_object(prolis, '/v1/a/c/img', image)
@@ -1136,10 +1128,9 @@ return [open(mnfst.image['path']).read(), sorted(id)]
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return [open(mnfst.image['path']).read(), sorted(id)]
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         image = 'This is image file'
         image_gz = StringIO('')
@@ -1172,10 +1163,9 @@ return [open(mnfst.image['path']).read(), sorted(id)]
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
     return [open(mnfst.image['path']).read(), sorted(id)]
-    '''[1:-1]
+    ''')
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         image = 'This is image file' * 10000
         self.create_object(prolis, '/v1/a/c/img', image)
@@ -1206,12 +1196,11 @@ return [open(mnfst.image['path']).read(), sorted(id)]
         image = 'This is image file'
         sysimage_path = os.path.join(_testdir, 'sysimage.tar')
 
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return open(mnfst.nvram['path']).read() + \
     str(mnfst.channels['/dev/sysimage1']['type']) + ' ' + \
     str(mnfst.channels['/dev/sysimage1']['path'])
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         img = open(sysimage_path, 'wb')
         img.write(image)
@@ -1253,8 +1242,7 @@ return open(mnfst.nvram['path']).read() + \
         image = 'This is image file'
         sysimage_path = os.path.join(_testdir, 'sysimage.tar')
 
-        nexe = trim(
-            r'''
+        nexe = trim(r'''
             return open(mnfst.nvram['path']).read() + \
                 str(mnfst.channels['/dev/sysimage1']['type']) + ' ' + \
                 str(mnfst.channels['/dev/sysimage1']['path']) + '\n' + \
@@ -1300,20 +1288,18 @@ return open(mnfst.nvram['path']).read() + \
     def test_QUERY_post_script_sysimage(self):
         self.setup_QUERY()
         prosrv = _test_servers[0]
-        script = \
-            r'''
+        script = trim(r'''
 #! file://sysimage1:bin/sh
 print 'Test'
-'''[1:-1]
-        nexe = \
-            r'''
+''')
+        nexe = trim(r'''
 import tarfile
 tar = tarfile.open(mnfst.image['path'])
 members = tar.getmembers()
 names = tar.getnames()
 file = tar.extractfile(members[0])
 return names[0] + '\n' + file.read()
-'''[1:-1]
+''')
         shell = StringIO(nexe)
         with self.create_tar({'bin/sh': shell}) as tar:
             with self.add_sysimage_device(tar):
@@ -1330,40 +1316,36 @@ return names[0] + '\n' + file.read()
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe = \
-            r'''
+        nexe = trim(r'''
 import tarfile
 tar = tarfile.open(mnfst.image['path'])
 members = tar.getmembers()
 file = tar.extractfile(members[0])
 return file.read()
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
-        script = \
-            r'''
+        script = trim(r'''
 #! swift://a/c/exe2
 print 'Test'
-'''[1:-1]
+''')
         req = self.zerovm_request()
         req.body = script
         req.headers['content-type'] = 'application/x-python'
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
         self.assertIn(script, res.body)
-        script = \
-            r'''
+        script = trim(r'''
 #! swift://a/aaa/bbb
 print 'Test'
-'''[1:-1]
+''')
         req.body = script
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 404)
         self.assertIn(' /a/aaa/bbb', res.body)
-        script = \
-            r'''
+        script = trim(r'''
 #! aaa/bbb
 print 'Test'
-'''[1:-1]
+''')
         req.body = script
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 400)
@@ -1375,12 +1357,11 @@ print 'Test'
         prosrv = _test_servers[0]
         orig_timeout = prosrv.immediate_response_timeout
         prosrv.immediate_response_timeout = 0.5
-        nexe = \
-            r'''
+        nexe = trim(r'''
 from time import sleep
 sleep(1)
 return 'slept'
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/slow.nexe', nexe)
         conf = [
             {
@@ -1434,12 +1415,11 @@ return 'slept'
         prosrv = _test_servers[0]
         orig_timeout = prosrv.immediate_response_timeout
         prosrv.immediate_response_timeout = 0.5
-        nexe = \
-            r'''
+        nexe = trim(r'''
 from time import sleep
 sleep(1)
 return 'slept'
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/slow.nexe', nexe)
         conf = [
             {
@@ -1492,10 +1472,9 @@ return 'slept'
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return open(mnfst.nvram['path']).read()
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         conf = [
             {
@@ -1751,10 +1730,9 @@ return open(mnfst.nvram['path']).read()
 
     def test_QUERY_networked_devices(self):
         self.setup_QUERY()
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return 'ok'
-'''[1:-1]
+''')
         prolis = _test_sockets[0]
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         conf = [
@@ -1794,8 +1772,7 @@ return 'ok'
 
     def test_networked_devices_multistage(self):
         self.setup_QUERY()
-        nexe = trim(
-            r'''
+        nexe = trim(r'''
             for t in bind_list:
                 err.write('%s, %s\n' % (t[1], t[0]))
             return 'ok'
@@ -1875,14 +1852,13 @@ return 'ok'
 
     def test_QUERY_network_resolve_multiple(self):
         self.setup_QUERY()
-        nexe = \
-            r'''
+        nexe = trim(r'''
 con_list.insert(
     0,
     re.sub(r'(?s).*args = ([^\n]+).*', r'\1', open(mnfst.nvram['path']).read())
 )
 return json.dumps(con_list)
-'''[1:-1]
+''')
         prolis = _test_sockets[0]
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         conf = [
@@ -2553,10 +2529,9 @@ return json.dumps(con_list)
                            self.get_random_numbers())
         self.create_object(prolis, '/v1/a/terasort/input/4.txt',
                            self.get_random_numbers())
-        nexe =\
-            r'''
+        nexe = trim(r'''
 return open(mnfst.nvram['path']).read()
-'''[1:-1]
+''')
         self.create_object(prolis, '/v1/a/terasort/bin/map', nexe)
         self.create_object(prolis, '/v1/a/terasort/bin/reduce', nexe)
         conf = [
@@ -2704,10 +2679,10 @@ return open(mnfst.nvram['path']).read()
         try:
             prosrv.network_type = 'opaque'
             prosrv.ignore_replication = True
-            nexe =\
+            nexe = trim(
                 r'''
 return open(mnfst.nvram['path']).read()
-'''[1:-1]
+''')
             self.create_object(prolis, '/v1/a/terasort/bin/map', nexe)
             self.create_object(prolis, '/v1/a/terasort/bin/reduce', nexe)
             conf = [

--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -204,9 +204,11 @@ def teardown():
 
 @contextmanager
 def save_globals():
-    orig_http_connect = getattr(swift.proxy.controllers.base, 'http_connect', None)
+    orig_http_connect = getattr(
+        swift.proxy.controllers.base, 'http_connect', None)
     orig_query_connect = getattr(proxyquery, 'http_connect', None)
-    orig_account_info = getattr(proxy_server.ObjectController, 'account_info', None)
+    orig_account_info = getattr(
+        proxy_server.ObjectController, 'account_info', None)
     try:
         yield True
     finally:
@@ -274,14 +276,14 @@ class TestProxyQuery(unittest.TestCase):
             randindex1 = random.randrange(count)
             randindex2 = random.randrange(count)
             numlist[randindex1], numlist[randindex2] =\
-            numlist[randindex2], numlist[randindex1]
+                numlist[randindex2], numlist[randindex1]
         if proto == 'binary':
             return struct.pack('%sI' % len(numlist), *numlist)
         else:
             return pickle.dumps(numlist, protocol=0)
 
     def get_sorted_numbers(self, min_num=0, max_num=10, proto='pickle'):
-        numlist = [i for i in range(min_num,max_num)]
+        numlist = [i for i in range(min_num, max_num)]
         if proto == 'binary':
             return struct.pack('%sI' % len(numlist), *numlist)
         else:
@@ -322,14 +324,14 @@ class TestProxyQuery(unittest.TestCase):
         self.create_object(prolis, '/v1/a/c/exe', self._nexescript)
 
         self.create_object(prolis, '/v1/a/c_in1/input1',
-                           self.get_random_numbers(0,10))
+                           self.get_random_numbers(0, 10))
         self.create_object(prolis, '/v1/a/c_in1/input2',
-                           self.get_random_numbers(10,20))
+                           self.get_random_numbers(10, 20))
         self.create_object(prolis, '/v1/a/c_in1/junk', 'junk')
         self.create_object(prolis, '/v1/a/c_in2/input1',
-                           self.get_random_numbers(20,30))
+                           self.get_random_numbers(20, 30))
         self.create_object(prolis, '/v1/a/c_in2/input2',
-                           self.get_random_numbers(30,40))
+                           self.get_random_numbers(30, 40))
         self.create_object(prolis, '/v1/a/c_in2/junk', 'junk')
         self.create_container(prolis, '/v1/userstats/a')
 
@@ -509,11 +511,16 @@ class TestProxyQuery(unittest.TestCase):
                     self.assertEqual(connect_count, len(conf[1]))
                     offset += len(bind_data)
                     for i in range(connect_count):
-                        host, port = struct.unpack_from('!4sH', reply, offset)[0:2]
+                        host, port = struct.unpack_from(
+                            '!4sH', reply, offset)[0:2]
                         offset += 6
                         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                        s.connect((socket.inet_ntop(socket.AF_INET, host), port))
-                        self.assertEqual(connection_map['%d->%d' % (id, connect_list[i])], port)
+                        s.connect(
+                            (socket.inet_ntop(socket.AF_INET, host), port))
+                        self.assertEqual(
+                            connection_map['%d->%d' % (id, connect_list[i])],
+                            port
+                        )
                     break
             sleep(0.2)
 
@@ -578,18 +585,18 @@ class TestProxyQuery(unittest.TestCase):
                 req.content_length = os.path.getsize(tar)
                 res = req.get_response(prosrv)
                 self.executed_successfully(res)
-                self.check_container_integrity(prosrv,
-                                               '/v1/a/c',
-                                               {
-                                                   'o2': self.get_sorted_numbers()
-                                               })
+                self.check_container_integrity(
+                    prosrv,
+                    '/v1/a/c',
+                    {'o2': self.get_sorted_numbers()}
+                )
 
     def test_QUERY_sort_store_stdout_stderr(self):
         self.setup_QUERY()
         conf = [
             {
                 'name': 'sort',
-                'exec':{'path': 'swift://a/c/exe'},
+                'exec': {'path': 'swift://a/c/exe'},
                 'file_list': [
                     {'device': 'stdin', 'path': 'swift://a/c/o'},
                     {'device': 'stdout', 'path': 'swift://a/c/o2'},
@@ -639,7 +646,8 @@ class TestProxyQuery(unittest.TestCase):
                 'exec': {'path': 'swift://a/c/exe'},
                 'file_list': [
                     {'device': 'stdin', 'path': 'swift://a/c/o'},
-                    {'device': 'stdout', 'content_type': 'application/x-pickle'}
+                    {'device': 'stdout',
+                        'content_type': 'application/x-pickle'}
                 ]
             }
         ]
@@ -657,7 +665,7 @@ class TestProxyQuery(unittest.TestCase):
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe =\
-r'''
+            r'''
 return 'Test Test'
 '''[1:-1]
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
@@ -693,7 +701,7 @@ return 'Test Test'
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe =\
-r'''
+            r'''
 return 'hello, world'
 '''[1:-1]
         self.create_object(prolis, '/v1/a/c/hello.nexe', nexe)
@@ -719,7 +727,7 @@ return 'hello, world'
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe =\
-r'''
+            r'''
 return 'hello, world'
 '''[1:-1]
         self.create_object(prolis, '/v1/a/c/hello.nexe', nexe)
@@ -747,7 +755,7 @@ return 'hello, world'
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe =\
-r'''
+            r'''
 return 'hello, world'
 '''[1:-1]
         self.create_object(prolis, '/v1/a/c/hello.nexe', nexe)
@@ -774,7 +782,7 @@ return 'hello, world'
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe =\
-r'''
+            r'''
 resp = '\n'.join([
     'HTTP/1.1 200 OK',
     'Content-Type: text/html',
@@ -946,22 +954,26 @@ return resp + out
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe =\
-r'''
+            r'''
 resp = '<html><body>Test this</body></html>'
 return resp
 '''[1:-1]
-        self.create_object(prolis, '/v1/a/c/exe2', nexe, content_type='application/x-nexe')
+        self.create_object(
+            prolis, '/v1/a/c/exe2', nexe, content_type='application/x-nexe')
         req = self.object_request('/v1/a/c/exe2')
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
         self.assertEqual(res.body, nexe)
-        req = Request.blank('/open/a/c/exe2?' + urlencode({'content_type': 'text/html'}))
+        req = Request.blank(
+            '/open/a/c/exe2?' + urlencode({'content_type': 'text/html'}))
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
         self.assertEqual(res.body, '<html><body>Test this</body></html>')
         self.assertEqual(res.headers['content-type'], 'text/html')
-        self.create_object(prolis, '/v1/a/c/my.nexe', nexe, content_type='application/x-nexe')
-        req = Request.blank('/open/a/c/my.nexe?' + urlencode({'content_type':'text/html'}))
+        self.create_object(
+            prolis, '/v1/a/c/my.nexe', nexe, content_type='application/x-nexe')
+        req = Request.blank(
+            '/open/a/c/my.nexe?' + urlencode({'content_type': 'text/html'}))
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
         self.assertEqual(res.body, '<html><body>Test this</body></html>')
@@ -972,7 +984,8 @@ return resp
                 'exec': {'path': 'swift://a/c/exe'},
                 'file_list': [
                     {'device': 'stdin', 'path': '{.object_path}'},
-                    {'device': 'stdout', 'content_type': 'application/x-pickle'}
+                    {'device': 'stdout',
+                        'content_type': 'application/x-pickle'}
                 ]
             }
         ]
@@ -994,7 +1007,7 @@ return resp
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe =\
-r'''
+            r'''
 return [open(mnfst.image['path']).read(), sorted(id)]
 '''[1:-1]
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
@@ -1025,7 +1038,7 @@ return [open(mnfst.image['path']).read(), sorted(id)]
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe =\
-r'''
+            r'''
 return [open(mnfst.image['path']).read(), sorted(id)]
 '''[1:-1]
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
@@ -1124,7 +1137,7 @@ return [open(mnfst.image['path']).read(), sorted(id)]
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe =\
-r'''
+            r'''
 return [open(mnfst.image['path']).read(), sorted(id)]
 '''[1:-1]
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
@@ -1156,35 +1169,35 @@ return [open(mnfst.image['path']).read(), sorted(id)]
                               pickle.loads(self.get_sorted_numbers())]))
 
     def test_QUERY_use_large_image(self):
-            self.setup_QUERY()
-            prolis = _test_sockets[0]
-            prosrv = _test_servers[0]
-            nexe =\
-    r'''
+        self.setup_QUERY()
+        prolis = _test_sockets[0]
+        prosrv = _test_servers[0]
+        nexe =\
+            r'''
     return [open(mnfst.image['path']).read(), sorted(id)]
     '''[1:-1]
-            self.create_object(prolis, '/v1/a/c/exe2', nexe)
-            image = 'This is image file' * 10000
-            self.create_object(prolis, '/v1/a/c/img', image)
-            conf = [
-                {
-                    'name': 'sort',
-                    'exec': {'path': 'swift://a/c/exe2'},
-                    'file_list': [
-                        {'device': 'stdin', 'path': 'swift://a/c/o'},
-                        {'device': 'stdout'},
-                        {'device': 'image', 'path': 'swift://a/c/img'}
-                    ]
-                }
-            ]
-            conf = json.dumps(conf)
-            req = self.zerovm_request()
-            req.body = conf
-            res = req.get_response(prosrv)
-            self.assertEqual(res.status_int, 200)
-            self.assertEqual(res.body,
-                             str(['This is image file' * 10000,
-                                  pickle.loads(self.get_sorted_numbers())]))
+        self.create_object(prolis, '/v1/a/c/exe2', nexe)
+        image = 'This is image file' * 10000
+        self.create_object(prolis, '/v1/a/c/img', image)
+        conf = [
+            {
+                'name': 'sort',
+                'exec': {'path': 'swift://a/c/exe2'},
+                'file_list': [
+                    {'device': 'stdin', 'path': 'swift://a/c/o'},
+                    {'device': 'stdout'},
+                    {'device': 'image', 'path': 'swift://a/c/img'}
+                ]
+            }
+        ]
+        conf = json.dumps(conf)
+        req = self.zerovm_request()
+        req.body = conf
+        res = req.get_response(prosrv)
+        self.assertEqual(res.status_int, 200)
+        self.assertEqual(res.body,
+                         str(['This is image file' * 10000,
+                              pickle.loads(self.get_sorted_numbers())]))
 
     def test_QUERY_use_sysimage(self):
         self.setup_QUERY()
@@ -1194,7 +1207,7 @@ return [open(mnfst.image['path']).read(), sorted(id)]
         sysimage_path = os.path.join(_testdir, 'sysimage.tar')
 
         nexe =\
-r'''
+            r'''
 return open(mnfst.nvram['path']).read() + \
     str(mnfst.channels['/dev/sysimage1']['type']) + ' ' + \
     str(mnfst.channels['/dev/sysimage1']['path'])
@@ -1222,10 +1235,14 @@ return open(mnfst.nvram['path']).read() + \
             req.body = conf
             res = req.get_response(prosrv)
             self.assertEqual(res.status_int, 200)
-            self.assertIn('[fstab]\n'
-                          'channel=/dev/sysimage1, mountpoint=/, access=ro, removable=no\n'
-                          '[args]\n'
-                          'args = sort\n', res.body)
+            self.assertIn(
+                '[fstab]\n'
+                'channel=/dev/sysimage1, mountpoint=/, access=ro, '
+                'removable=no\n'
+                '[args]\n'
+                'args = sort\n',
+                res.body
+            )
             self.assertIn('%d %s' % (3, sysimage_path),
                           res.body)
 
@@ -1284,12 +1301,12 @@ return open(mnfst.nvram['path']).read() + \
         self.setup_QUERY()
         prosrv = _test_servers[0]
         script = \
-r'''
+            r'''
 #! file://sysimage1:bin/sh
 print 'Test'
 '''[1:-1]
         nexe = \
-r'''
+            r'''
 import tarfile
 tar = tarfile.open(mnfst.image['path'])
 members = tar.getmembers()
@@ -1314,7 +1331,7 @@ return names[0] + '\n' + file.read()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe = \
-r'''
+            r'''
 import tarfile
 tar = tarfile.open(mnfst.image['path'])
 members = tar.getmembers()
@@ -1323,7 +1340,7 @@ return file.read()
 '''[1:-1]
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         script = \
-r'''
+            r'''
 #! swift://a/c/exe2
 print 'Test'
 '''[1:-1]
@@ -1334,7 +1351,7 @@ print 'Test'
         self.assertEqual(res.status_int, 200)
         self.assertIn(script, res.body)
         script = \
-r'''
+            r'''
 #! swift://a/aaa/bbb
 print 'Test'
 '''[1:-1]
@@ -1343,7 +1360,7 @@ print 'Test'
         self.assertEqual(res.status_int, 404)
         self.assertIn(' /a/aaa/bbb', res.body)
         script = \
-r'''
+            r'''
 #! aaa/bbb
 print 'Test'
 '''[1:-1]
@@ -1359,7 +1376,7 @@ print 'Test'
         orig_timeout = prosrv.immediate_response_timeout
         prosrv.immediate_response_timeout = 0.5
         nexe = \
-r'''
+            r'''
 from time import sleep
 sleep(1)
 return 'slept'
@@ -1418,7 +1435,7 @@ return 'slept'
         orig_timeout = prosrv.immediate_response_timeout
         prosrv.immediate_response_timeout = 0.5
         nexe = \
-r'''
+            r'''
 from time import sleep
 sleep(1)
 return 'slept'
@@ -1476,7 +1493,7 @@ return 'slept'
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
         nexe =\
-r'''
+            r'''
 return open(mnfst.nvram['path']).read()
 '''[1:-1]
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
@@ -1538,10 +1555,13 @@ return open(mnfst.nvram['path']).read()
         req = self.zerovm_request()
         req.body = conf
         res = req.get_response(prosrv)
-        self.assertIn('[fstab]\n'
-                      'channel=/dev/image, mountpoint=/, access=ro, removable=no\n'
-                      '[args]\n'
-                      'args = sort\n', res.body)
+        self.assertIn(
+            '[fstab]\n'
+            'channel=/dev/image, mountpoint=/, access=ro, removable=no\n'
+            '[args]\n'
+            'args = sort\n',
+            res.body
+        )
         conf = [
             {
                 'name': 'sort',
@@ -1582,7 +1602,8 @@ return open(mnfst.nvram['path']).read()
                     'path': 'swift://a/c/exe2'
                 },
                 'file_list': [
-                    {'device': 'input', 'path': 'swift://a/c/o', 'mode': 'file'},
+                    {'device': 'input', 'path': 'swift://a/c/o',
+                        'mode': 'file'},
                     {'device': 'stdout', 'mode': 'char'},
                     {'device': 'image', 'path': 'swift://a/c/img'}
                 ]
@@ -1718,18 +1739,20 @@ return open(mnfst.nvram['path']).read()
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
         self.assertIn('finished', res.body)
-        self.assert_(re.match('tcp://127.0.0.1:\d+, /dev/out/%s' % conf[0]['connect'][0], res.body))
+        self.assert_(re.match('tcp://127.0.0.1:\d+, /dev/out/%s' %
+                              conf[0]['connect'][0], res.body))
 
         req = self.object_request('/v1/a/c/o3')
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
         self.assertIn('finished', res.body)
-        self.assert_(re.match('tcp://127.0.0.1:\d+, /dev/out/%s' % conf[1]['connect'][0], res.body))
+        self.assert_(re.match('tcp://127.0.0.1:\d+, /dev/out/%s' %
+                              conf[1]['connect'][0], res.body))
 
     def test_QUERY_networked_devices(self):
         self.setup_QUERY()
         nexe =\
-r'''
+            r'''
 return 'ok'
 '''[1:-1]
         prolis = _test_sockets[0]
@@ -1849,12 +1872,15 @@ return 'ok'
         self.assertEqual(res.status_int, 200)
         # bind stdin to network source
         self.assert_(re.match('tcp://0:\d+, /dev/stdin', res.body))
-        
+
     def test_QUERY_network_resolve_multiple(self):
         self.setup_QUERY()
-        nexe =\
-r'''
-con_list.insert(0, re.sub(r'(?s).*args = ([^\n]+).*', r'\1', open(mnfst.nvram['path']).read()))
+        nexe = \
+            r'''
+con_list.insert(
+    0,
+    re.sub(r'(?s).*args = ([^\n]+).*', r'\1', open(mnfst.nvram['path']).read())
+)
 return json.dumps(con_list)
 '''[1:-1]
         prolis = _test_sockets[0]
@@ -1887,7 +1913,8 @@ return json.dumps(con_list)
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
 
-        results = [json.loads(r) for r in re.findall(r'(?s)(\[.*?\](?=\[|$))', res.body)]
+        results = [json.loads(r) for r in re.findall(
+            r'(?s)(\[.*?\](?=\[|$))', res.body)]
         pattern = '/dev/out/([^\s]+)\', \'tcp://127.0.0.1:\d+'
         for r in results:
             if 'sort-1' in r[0]:
@@ -1940,7 +1967,8 @@ return json.dumps(con_list)
         req.body = jconf
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
-        self.assertEqual(res.body, self.get_sorted_numbers(0, 10) + self.get_sorted_numbers(10, 20))
+        self.assertEqual(res.body, self.get_sorted_numbers(
+            0, 10) + self.get_sorted_numbers(10, 20))
 
     def test_QUERY_read_container_wildcard(self):
         self.setup_QUERY()
@@ -2046,7 +2074,8 @@ return json.dumps(con_list)
         self.assertEqual(res.status_int, 200)
         time_dict = {}
         # each header is duplicated because we have replication level set to 2
-        self.assertEqual(res.headers['x-nexe-system'], 'sort-1,sort-1,sort-2,sort-2')
+        self.assertEqual(
+            res.headers['x-nexe-system'], 'sort-1,sort-1,sort-2,sort-2')
         self.assertEqual(res.headers['x-nexe-status'], 'ok.,ok.,ok.,ok.')
         self.assertEqual(res.headers['x-nexe-retcode'], '0,0,0,0')
         self.check_container_integrity(prosrv,
@@ -2100,31 +2129,35 @@ return json.dumps(con_list)
         req.body = jconf
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
-        self.assertEqual(res.headers['x-nexe-system'], 'sort-1,sort-2,sort-3,sort-4')
+        self.assertEqual(
+            res.headers['x-nexe-system'], 'sort-1,sort-2,sort-3,sort-4')
         self.assertEqual(res.headers['x-nexe-status'], 'ok.,ok.,ok.,ok.')
         self.assertEqual(res.headers['x-nexe-retcode'], '0,0,0,0')
-        self.check_container_integrity(prosrv,
-                                       '/v1/a/c_out1',
-                                       {
-                                           'output1': self.get_sorted_numbers(0, 10),
-                                           'output2': self.get_sorted_numbers(10, 20)
-                                       })
-        self.check_container_integrity(prosrv,
-                                       '/v1/a/c_out2',
-                                       {
-                                           'output1': self.get_sorted_numbers(20, 30),
-                                           'output2': self.get_sorted_numbers(30, 40)
-                                       })
+        self.check_container_integrity(
+            prosrv,
+            '/v1/a/c_out1',
+            {'output1': self.get_sorted_numbers(0, 10),
+             'output2': self.get_sorted_numbers(10, 20)}
+        )
+        self.check_container_integrity(
+            prosrv,
+            '/v1/a/c_out2',
+            {'output1': self.get_sorted_numbers(20, 30),
+             'output2': self.get_sorted_numbers(30, 40)}
+        )
 
     def test_QUERY_calls_authorize(self):
-        raise SkipTest # there is no pre-authorization right now, maybe we do not need it at all
+        # there is no pre-authorization right now, maybe we do not need it at
+        # all
+        raise SkipTest
         called = [False]
+
         def authorize(req):
             called[0] = True
             return HTTPUnauthorized(request=req)
         with save_globals():
             proxy_server.http_connect =\
-            fake_http_connect(200, 200, 201, 201, 201)
+                fake_http_connect(200, 200, 201, 201, 201)
             prosrv = _test_servers[0]
             req = self.zerovm_object_request()
             req.environ['swift.authorize'] = authorize
@@ -2198,7 +2231,8 @@ return json.dumps(con_list)
         req = self.zerovm_request()
         req.body = conf
         res = req.get_response(prosrv)
-        self.assertEqual(res.body, 'Error 404 Not Found while fetching /a/c/error')
+        self.assertEqual(
+            res.body, 'Error 404 Not Found while fetching /a/c/error')
         self.assertEqual(res.status_int, 404)
 
     def test_QUERY_missing_required_fields(self):
@@ -2461,7 +2495,8 @@ return json.dumps(con_list)
             req.body = conf
             res = req.get_response(prosrv)
             self.assertEqual(res.status_int, 400)
-            self.assertEqual(res.body, 'Error querying object server for account: a')
+            self.assertEqual(
+                res.body, 'Error querying object server for account: a')
 
     def test_QUERY_config_parser(self):
 
@@ -2520,7 +2555,7 @@ return json.dumps(con_list)
         self.create_object(prolis, '/v1/a/terasort/input/4.txt',
                            self.get_random_numbers())
         nexe =\
-r'''
+            r'''
 return open(mnfst.nvram['path']).read()
 '''[1:-1]
         self.create_object(prolis, '/v1/a/terasort/bin/map', nexe)
@@ -2596,7 +2631,8 @@ return open(mnfst.nvram['path']).read()
         # for name, node in controller.nodes.iteritems():
         #     self.assertEqual(node.replicate, 1)
         #     self.assertEqual(node.replicas, [])
-        #print json.dumps(controller.nodes, sort_keys=True, indent=2, cls=proxyquery.NodeEncoder)
+        # print json.dumps(controller.nodes, sort_keys=True, indent=2,
+        # cls=proxyquery.NodeEncoder)
 
     def test_opaque_config(self):
 
@@ -2670,7 +2706,7 @@ return open(mnfst.nvram['path']).read()
             prosrv.network_type = 'opaque'
             prosrv.ignore_replication = True
             nexe =\
-r'''
+                r'''
 return open(mnfst.nvram['path']).read()
 '''[1:-1]
             self.create_object(prolis, '/v1/a/terasort/bin/map', nexe)

--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -1422,7 +1422,7 @@ return 'slept'
         self.assertEqual(res.status_int, 200)
         raised = 0
         try:
-            rep = json.loads(res.body)
+            json.loads(res.body)
         except Exception:
             raised += 1
         self.assertEqual(raised, 0)
@@ -1482,7 +1482,7 @@ return 'slept'
         self.assertEqual(res.status_int, 200)
         raised = 0
         try:
-            rep = json.loads(res.body)
+            json.loads(res.body)
         except Exception:
             raised += 1
         self.assertEqual(raised, 0)
@@ -2072,7 +2072,6 @@ return json.dumps(con_list)
         req.body = jconf
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
-        time_dict = {}
         # each header is duplicated because we have replication level set to 2
         self.assertEqual(
             res.headers['x-nexe-system'], 'sort-1,sort-1,sort-2,sort-2')
@@ -2162,7 +2161,7 @@ return json.dumps(con_list)
             req = self.zerovm_object_request()
             req.environ['swift.authorize'] = authorize
             req.body = '1234'
-            res = req.get_response(prosrv)
+            req.get_response(prosrv)
         self.assert_(called[0])
 
     def test_QUERY_request_client_disconnect_attr(self):

--- a/test/unit/zerovm_mock.py
+++ b/test/unit/zerovm_mock.py
@@ -13,6 +13,10 @@ try:
     import simplejson as json
 except ImportError:
     import json
+# NOTE(LB): This assert is here to silence pyflakes, because it complains about
+# an unused import. If we remove the import, however, some tests will fail.
+# I'm not exactly sure why. There's some funny monkey patching going on here.
+assert json
 
 
 def errdump(zvm_errcode, nexe_validity, nexe_errcode, nexe_etag,

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,8 @@ commands = {posargs}
 
 [testenv:pep8]
 deps = pep8
-commands = pep8 setup.py zerocloud
+commands = pep8 setup.py zerocloud test
 
 [testenv:pyflakes]
 deps = pyflakes
-commands = pyflakes setup.py zerocloud
+commands = pyflakes setup.py zerocloud test


### PR DESCRIPTION
This change
- fixes all pep8 and pyflakes errors in the `test` package
- makes `tox` run pep8 and pyflakes on the `test` package, in addition to the `zerocloud` package
- fixes some other minor multiline string style issues (pep8/pyflakes were not complaining about these)
