### PR TITLE
added optional `name` argument to `exe` property

### DIFF
--- a/doc/Servlets.md
+++ b/doc/Servlets.md
@@ -8,6 +8,7 @@ JSON format describing a servlet configuration
         <b>"name"</b>:"node name/alias, alphanumeric only", <b>required</b>
         <b>"exec"</b>:{    <b>required</b>
             <b>"path"</b>:"executable path, URL (see Url.md)", <b>required</b>
+            "name":"executable name", <i>optional</i>
             "args":"executable command line", <i>optional</i>
             "env":{    <i>executable environment, optional</i>
                 "key1":"value1",
@@ -215,6 +216,11 @@ It can be controlled with the `attach` keyword.
 Default value for attach is `default` which means that the following strategy will be employed by middleware: _code will be sent to the storage node that holds the first (topmost) `swift://` path encountered in the job config. But before that the paths will be sorted by placing `read only` objects on top, `write only` after the former ones, and all other objects at the bottom. Sort will be a stable one. If such path does not exist the node for a session will be chosen randomly._  
 If another location is desired, user needs to specify a device in `attach`, ex.: `"attach": "stdout"`.  
 If the device is a `swift://` path the session will be started in co-location with the desired object. If such device is not a `swift://` path the node for a session will be chosen randomly.
+
+18. Executable can have `exec.name` property.
+It is an optional argument that sets executable name to the supplied string.  
+Executable name is visible to the application under `ARGV[0]`, as usual.  
+If `exec.name` is not supplied, the name would be set to the cluster node `name` property
 
 ## Examples
 

--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -836,10 +836,10 @@ return resp + out
         self.setup_QUERY()
         prolis = _test_sockets[0]
         prosrv = _test_servers[0]
-        nexe =\
-r'''
-return pickle.dumps(open(mnfst.nvram['path']).read())
-'''[1:-1]
+        nexe = trim(
+            r'''
+            return pickle.dumps(open(mnfst.nvram['path']).read())
+            ''')
         self.create_object(prolis, '/v1/a/c/exe2', nexe)
         conf = [
             {
@@ -892,6 +892,7 @@ return pickle.dumps(open(mnfst.nvram['path']).read())
         conf = json.dumps(conf)
         req = self.zerovm_request()
         req.body = conf
+        req.query_string = 'param1=v1&param2=v2'
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
         out = pickle.loads(res.body)
@@ -901,6 +902,43 @@ return pickle.dumps(open(mnfst.nvram['path']).read())
         self.assertIn('name=DOCUMENT_ROOT, value=/dev/stdin', out)
         self.assertIn('name=PATH_INFO, value=/a/c/o3', out)
         self.assertIn('name=CONTENT_LENGTH, value=%d' % content_length, out)
+        self.assertIn('name=SCRIPT_NAME, value=http', out)
+        self.assertIn('name=SCRIPT_FILENAME, value=swift://a/c/exe2', out)
+        self.assertIn('name=QUERY_STRING, value=%s' % req.query_string, out)
+        self.check_container_integrity(prosrv, '/v1/a/c', {})
+        conf = [
+            {
+                'name': 'http2',
+                'exec': {
+                    'path': 'swift://a/c/exe2',
+                    'name': 'http_script'
+                },
+                'file_list': [
+                    {
+                        'device': 'stdout',
+                        'content_type': 'text/plain',
+                    },
+                    {
+                        'device': 'stdin',
+                        'path': 'swift://a/c/o3'
+                    }
+                ]
+            }
+        ]
+        conf = json.dumps(conf)
+        req = self.zerovm_request()
+        req.body = conf
+        res = req.get_response(prosrv)
+        self.assertEqual(res.status_int, 200)
+        out = pickle.loads(res.body)
+        self.assertIn('name=CONTENT_TYPE, value=application/x-pickle', out)
+        self.assertIn('name=HTTP_X_OBJECT_META_KEY1, value=val1', out)
+        self.assertIn('name=HTTP_X_OBJECT_META_KEY2, value=val2', out)
+        self.assertIn('name=DOCUMENT_ROOT, value=/dev/stdin', out)
+        self.assertIn('name=PATH_INFO, value=/a/c/o3', out)
+        self.assertIn('name=CONTENT_LENGTH, value=%d' % content_length, out)
+        self.assertIn('name=SCRIPT_NAME, value=http_script', out)
+        self.assertIn('name=SCRIPT_FILENAME, value=swift://a/c/exe2', out)
         self.check_container_integrity(prosrv, '/v1/a/c', {})
 
     def test_QUERY_GET_response(self):

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -301,7 +301,7 @@ def is_cache_path(location):
 
 class ZvmNode(object):
     def __init__(self, id=None, name=None, exe=None, args=None, env=None,
-                 replicate=1, attach=None):
+                 replicate=1, attach=None, exe_name=None):
         self.id = id
         self.name = name
         self.exe = exe
@@ -316,6 +316,7 @@ class ZvmNode(object):
         self.wildcards = None
         self.attach = attach
         self.access = ''
+        self.exe_name = exe_name
 
     def copy(self, id, name=None):
         newnode = deepcopy(self)
@@ -369,7 +370,8 @@ class ZvmNode(object):
             request.environ.get('SERVER_PROTOCOL', 'HTTP/1.0')
         self.env['SERVER_SOFTWARE'] = 'zerocloud'
         self.env['GATEWAY_INTERFACE'] = 'CGI/1.1'
-        self.env['SCRIPT_NAME'] = self.exe
+        self.env['SCRIPT_NAME'] = self.exe_name or self.name
+        self.env['SCRIPT_FILENAME'] = self.exe
         self.env['PATH_INFO'] = request.path_info
         self.env['REQUEST_METHOD'] = 'GET'
         self.env['HTTP_REFERER'] = request.referer

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -704,7 +704,8 @@ class ClusterConfigParser(object):
             for k, v in config['env'].iteritems():
                 if v:
                     env += ENV_ITEM % (k, quote_for_env(v))
-        args = '[args]\nargs = %s' % config['name']
+        exe_name = config.get('exe_name') or config['name']
+        args = '[args]\nargs = %s' % exe_name
         if config.get('args'):
             args += ' %s' % config['args']
         args += '\n'
@@ -819,7 +820,8 @@ def _create_node(node_config):
             'Invalid nexe property for %s' % name)
     replicate = node_config.get('replicate', 1)
     attach = node_config.get('attach', 'default')
-    return ZvmNode(0, name, exe, args, env, replicate, attach)
+    exe_name = nexe.get('name')
+    return ZvmNode(0, name, exe, args, env, replicate, attach, exe_name)
 
 
 def _create_channel(channel, node, default_content_type=None):


### PR DESCRIPTION
The new job description property `exe.name` is introduced by the patch
It allows user to explicitly set a name for executable (the value of `ARGV[0]`)
The property is optional, if not supplied, the default method for setting `ARGV[0]` will be used
Currently the default is to set it to "node name"
Docs updated.
