### PR TITLE
added option to ignore empty or small objects

### DIFF
--- a/doc/Servlets.md
+++ b/doc/Servlets.md
@@ -27,6 +27,7 @@ JSON format describing a servlet configuration
                 "metakey2":"value2"
                 }
             "mode": "changes stat() type of device, can be 'file', 'block', 'char' or 'pipe'", <i>optional</i>
+            "min_size":0, <i>minimal data size in bytes, optional, ignored for read-only devices</i>
             },
         ],
         "count":1, <i>number of nodes, optional</i>
@@ -229,7 +230,12 @@ If `exec.name` is not supplied, the name would be set to the cluster node `name`
 with some key difference: it is never co-located with the executable 
 (unless this is the only `READABLE` device). Its primarily purpose is to be used as a script source input 
 for apps written in a scripting language (python, for example).
-  
+
+20. Each `WRITABLE` device can have `min_size` property set. 
+It defines what will be the minimal data size produced by the device. 
+If device produced less than the amount it won't be processed, saved or otherwise used.
+Default is `min_size: 0` which means that even totally empty data files will be written to disk or serialized to user.
+
 ## Examples
 
 

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -409,7 +409,7 @@ class ZvmNode(object):
 class ZvmChannel(object):
     def __init__(self, device, access, path=None,
                  content_type=None, meta_data=None,
-                 mode=None, removable='no', mountpoint='/'):
+                 mode=None, removable='no', mountpoint='/', min_size=0):
         self.device = device
         self.access = access
         self.path = path
@@ -418,6 +418,7 @@ class ZvmChannel(object):
         self.mode = mode
         self.removable = removable
         self.mountpoint = mountpoint
+        self.min_size = min_size
 
 
 class NodeEncoder(json.JSONEncoder):

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -836,6 +836,7 @@ def _create_channel(channel, node, default_content_type=None):
     access = DEVICE_MAP.get(device, -1)
     mode = channel.get('mode', None)
     meta = channel.get('meta', {})
+    min_size = channel.get('min_size', 0)
     content_type = channel.get('content_type',
                                default_content_type if path else 'text/html')
     if access & ACCESS_READABLE and path:
@@ -846,4 +847,5 @@ def _create_channel(channel, node, default_content_type=None):
             raise ClusterConfigParsingError('Invalid path %s in %s'
                                             % (path.url, node.name))
     return ZvmChannel(device, access, path=path,
-                      content_type=content_type, meta_data=meta, mode=mode)
+                      content_type=content_type, meta_data=meta,
+                      mode=mode, min_size=min_size)

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -1050,6 +1050,8 @@ class ObjectQueryMiddleware(object):
                     else:
                         ch['size'] = \
                             self.os_interface.path.getsize(ch['lpath'])
+                    if ch['size'] < ch['min_size']:
+                        continue
                     info = tar_stream.create_tarinfo(ftype=REGTYPE,
                                                      name=ch['device'],
                                                      size=ch['size'])


### PR DESCRIPTION
adding `min_size:1` or any other integer to `device` definition in job description
will instruct objectquery middleware to ignore objects of the size smaller than `min_size`
it can be good for various error channels, for example placing `min_size:1` on `stderr` and saving `stderr` as object
will produce the object only in case where `stderr` was not empty
