### PR TITLE
requirements.txt: pin swift 1.13.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
---find-links https://launchpad.net/swift/
 eventlet>=0.9.15
 greenlet>=0.3.1
 pastedeploy>=1.3.3
 simplejson>=2.0.9
 xattr>=0.4
 python-swiftclient
-swift>=1.13.0
+# NOTE(larsbutler): ZeroCloud tests break with swift 2.0.0,
+# and the one of the only sources for a 1.13.x verison is github.
+-e git+https://github.com/openstack/swift.git@1.13.1#egg=swift


### PR DESCRIPTION
With the release of swift 2.0.0, some tests in ZeroCloud broke.

This commit
https://github.com/openstack/swift/commit/3824ff3df71975194fa1b050255c0da8c1acc598
took away the `object_ring` kwarg from the
swift.proxy.server.Application class, which the ZeroCloud tests were
using.

Until we can update everything to be compatible with swift 2.0, we can
stay at version 1.13.1.
