### PR TITLE
added ability to use POST data as channel input

### DIFF
--- a/doc/Requests.md
+++ b/doc/Requests.md
@@ -24,6 +24,16 @@ differently:
 - any other `Content-Type` - [POST a script](#post-any-other-file) to
   be handled by some interpreter or shell executable.
 
+You can also add `X-Zerovm-Source` header to the POST request  
+The header accepts the following format:  
+`X-Zerovm-Source: <Swift Url>` (please see doc/Url.md on Swift Url format)  
+If `X-Zerovm-Source` was supplied the job description file, 
+image file or script file will be fetched from that url.
+And POST request payload can be attached to any readable (`stdin`, `input` or 
+`script`) channel instead.  
+Notice: the object that `X-Zerovm-Source` points to should have a 
+proper `Content-Type` set to get the behaviour described above.
+
 ### POST a job description
 
 This POST will work only if url path info is of the form:

--- a/doc/Servlets.md
+++ b/doc/Servlets.md
@@ -79,6 +79,15 @@ Only the following devices can be supplied without `path` property set
     If the device is a 'system image' it also does not have a path,
     its path is predefined in `zerovm_sysimage_devices` configuration directive
 
+    Devices `stdin`, `input` and `script` can be supplied without path in 
+    case where the `X-Zerovm-Source` header is used in request.
+    
+    If `X-Zerovm-Source` header is used the POST payload will be used as a 
+    channel payload for these devices. You cannot have multiple readable 
+    devices without a path. But the same POST payload can be sent to 
+    different job nodes if each one of then has one readable device with no 
+    path.
+    
 3. Path property `devices[i].path` can contain wild-card(s)  
 Asterisk `*` character must be used as wild-card  
 Any number of wild-cards is allowed in one path  

--- a/test/unit/test_objectquery.py
+++ b/test/unit/test_objectquery.py
@@ -1481,7 +1481,8 @@ class TestObjectQuery(unittest.TestCase):
             fd, name = mkstemp()
             self.assertEqual(resp.status_int, 400)
             self.assertEqual(
-                resp.body, 'Could not resolve channel path: bla-bla')
+                resp.body, 'Could not resolve channel path bla-bla for '
+                           'device: stdin')
 
     def test_QUERY_filter_factory(self):
         app = objectquery.filter_factory(self.conf)(FakeApp(self.conf))

--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -3379,3 +3379,62 @@ class TestProxyQuery(unittest.TestCase):
         self.assertTrue(3 not in pqm.standalone_policies)
         self.assertEqual(pqm.logger.lines_dict['warning'][0],
                          'Could not load storage policy: three')
+
+    def test_sort_from_request(self):
+        self.setup_QUERY()
+        conf = [
+            {
+                'name': 'sort',
+                'exec': {'path': 'swift://a/c/exe'},
+                'devices': [
+                    {'name': 'stdin'},
+                    {'name': 'stdout', 'path': 'swift://a/c/o2'}
+                ]
+            }
+        ]
+        conf = json.dumps(conf)
+        prosrv = _test_servers[0]
+        prolis = _test_sockets[0]
+        req = self.zerovm_tar_request()
+        sysmap = StringIO(conf)
+        with self.create_tar({CLUSTER_CONFIG_FILENAME: sysmap}) as tar:
+            req.body_file = open(tar, 'rb')
+            req.content_length = os.path.getsize(tar)
+            res = req.get_response(prosrv)
+            self.assertEqual(res.status_int, 400)
+            self.create_object(prolis, '/v1/a/c/myapp',
+                               open(tar, 'rb').read(),
+                               content_type='application/x-tar')
+            req = self.zerovm_request()
+            req.headers['x-zerovm-source'] = 'swift://a/c/myapp'
+            req.headers['content-type'] = 'application/x-pickle'
+            random_data = self.get_random_numbers()
+            data = StringIO(random_data)
+            req.body_file = data
+            req.content_length = len(random_data)
+            res = req.get_response(prosrv)
+            self.executed_successfully(res)
+            self.check_container_integrity(prosrv,
+                                           '/v1/a/c',
+                                           {
+                                               'o2': self.get_sorted_numbers(),
+                                               'myapp': open(tar, 'rb').read()
+                                           })
+        self.create_object(prolis, '/v1/a/c/sort.json',
+                           conf,
+                           content_type='application/json')
+        req = self.zerovm_request()
+        req.headers['x-zerovm-source'] = 'swift://a/c/sort.json'
+        req.headers['content-type'] = 'application/x-pickle'
+        random_data = self.get_random_numbers()
+        data = StringIO(random_data)
+        req.body_file = data
+        req.content_length = len(random_data)
+        res = req.get_response(prosrv)
+        self.executed_successfully(res)
+        self.check_container_integrity(prosrv,
+                                       '/v1/a/c',
+                                       {
+                                           'o2': self.get_sorted_numbers(),
+                                           'sort.json': conf
+                                       })

--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -2621,8 +2621,9 @@ class TestProxyQuery(unittest.TestCase):
             req.body = conf
             res = req.get_response(prosrv)
             self.assertEqual(res.status_int, 400)
-            self.assertEqual(res.body, ('Could not resolve channel path: '
-                                        'swift://a/%s' % path) * 2)
+            self.assertEqual(res.body, ('Could not resolve channel path '
+                                        'swift://a/%s for device: stdin'
+                                        % path) * 2)
             self.assertEqual(res.headers['x-nexe-system'], 'sort,sort')
             self.assertEqual(res.headers['x-nexe-status'],
                              'ZeroVM did not run,ZeroVM did not run')

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -771,6 +771,18 @@ class ClusterConfigParser(object):
             if node.replicate == 0:
                 node.replicate = 1
 
+    def get_list_of_remote_objects(self, node):
+        channels = []
+        if is_swift_path(node.exe):
+            channels.append(ZvmChannel('boot', None, path=node.exe))
+        for ch in node.channels:
+            if is_swift_path(ch.path) \
+                    and (ch.access & (ACCESS_READABLE | ACCESS_CDR)) \
+                    and not self.is_sysimage_device(ch.device) \
+                    and ch.path.path != getattr(node, 'path_info', None):
+                channels.append(ch)
+        return channels
+
 
 def _add_connected_device(devices, channel, zvm_node):
     if not devices.get(zvm_node.name, None):

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -844,10 +844,10 @@ class ObjectQueryMiddleware(object):
                     if not ch.get('lpath'):
                         if not chan_path or is_image_path(chan_path)\
                                 or is_swift_path(chan_path):
-                            return HTTPBadRequest(request=req,
-                                                  body='Could not resolve '
-                                                       'channel path: %s'
-                                                       % ch['path'])
+                            return HTTPBadRequest(
+                                request=req,
+                                body='Could not resolve channel path %s for '
+                                     'device: %s' % (ch['path'], ch['device']))
                 elif ch['access'] & ACCESS_WRITABLE:
                     writable_tmpdir = self.get_writable_tmpdir(device)
                     (output_fd, output_fn) = mkstemp(dir=writable_tmpdir)


### PR DESCRIPTION
using `X-Zerovm-Source` header clients can now attach a POST request payload to a job (even clustered one)
docs updated
