### PR TITLE
rewrite timeout handling

### DIFF
--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -43,6 +43,8 @@ See below.
 
 `zerovm_daemons = ''` - list of json encoded job descriptions that will be used as daemon configs on the server startup. Format of the jobs is exactly as described in `Servlets.md`. The daemonized versions of the jobs will be lazy-loaded, i.e. no daemon will run until some user requests a job that matches one of the job configs passed in that variable.
 
+`zerovm_timeout = 10` - time to wait for ZeroVM session to end, in seconds
+
 ### objectquery middleware
 
 Configuration file: `object-server.conf`
@@ -60,7 +62,7 @@ Other configuration strings (default value after equals sign):
 
 `zerovm_maxqueue = 3` - maximum number of ZeroVM execution requests in queue, waiting for their run.
 
-`zerovm_timeout = 5` - timeout for each ZeroVM session, in seconds. Hypervisor process is terminated after timeout.
+`zerovm_timeout = 10` - timeout for ZeroVM session in pre-vaidation time, in seconds
 
 `zerovm_kill_timeout = 1` - if after termination signal ZeroVM hypervisor is not dead Zerocloud waits this amount of time in seconds and then issues a kill signal.
 

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -105,6 +105,8 @@ RE_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
               unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
               unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),)
 
+TIMEOUT_GRACE = 0.5
+
 
 def merge_headers(current, new):
     if hasattr(new, 'keys'):

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -529,30 +529,33 @@ class ClusterConfigParser(object):
         return self.sysimage_devices.get(device_name, None)
 
     def prepare_for_daemon(self, config, nvram_file, zerovm_nexe,
-                           local_object, daemon_sock):
+                           local_object, daemon_sock, timeout=None):
         return self.prepare_zerovm_files(config, nvram_file,
                                          local_object=local_object,
                                          zerovm_nexe=zerovm_nexe,
                                          use_dev_self=False,
-                                         job=daemon_sock)
+                                         job=daemon_sock,
+                                         timeout=timeout)
 
-    def prepare_for_forked(self, config, nvram_file, local_object):
+    def prepare_for_forked(self, config, nvram_file, local_object,
+                           timeout=None):
         return self.prepare_zerovm_files(config, nvram_file,
                                          local_object=local_object,
                                          zerovm_nexe=None,
                                          use_dev_self=False,
-                                         job=None)
+                                         job=None, timeout=timeout)
 
     def prepare_for_standalone(self, config, nvram_file, zerovm_nexe,
-                               local_object):
+                               local_object, timeout=None):
         return self.prepare_zerovm_files(config, nvram_file,
                                          local_object=local_object,
                                          zerovm_nexe=zerovm_nexe,
                                          use_dev_self=True,
-                                         job=None)
+                                         job=None, timeout=timeout)
 
     def prepare_zerovm_files(self, config, nvram_file, local_object=None,
-                             zerovm_nexe=None, use_dev_self=True, job=None):
+                             zerovm_nexe=None, use_dev_self=True, job=None,
+                             timeout=None):
         """
         Prepares all the files needed for zerovm session run
 
@@ -565,6 +568,8 @@ class ClusterConfigParser(object):
 
         :returns zerovm manifest data as string
         """
+        if not timeout:
+            timeout = self.parser_config['manifest']['Timeout']
         zerovm_inputmnfst = (
             'Version=%s\n'
             'Program=%s\n'
@@ -573,7 +578,7 @@ class ClusterConfigParser(object):
             % (
                 self.parser_config['manifest']['Version'],
                 zerovm_nexe or '/dev/null',
-                self.parser_config['manifest']['Timeout'],
+                timeout,
                 self.parser_config['manifest']['Memory']
             ))
         if job:


### PR DESCRIPTION
the handling of timeouts was overly complex and had rather strange defaults
this patch simplifes the configuration for timeouts
now proxy middleware handles timeouts exclusively and `zerovm_timeout` value in object middleware is used only for validation purposes
now proxy middleware config supports `zerovm_timeout` as one of the config values
now `node_timeout` and `zerovm_timeout` are essentially the same, with `zerovm_timeout` being preferred if exists
there is a new hardcoded value `TIMEOUT_GRACE` which tries to gracefully shutdown the whole timeout chain to correctly get the results from lower levels
pseudocode:

```
with proxy.Timeout(timeout + TIMEOUT_GRACE * 2):
    with object.Timeout(timeout + TIMEOUT_GRACE):
        with zerovm.Timeout(timeout):
            # run zerovm session
```

docs updated
