### PR TITLE
better pass response headers to user

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -997,8 +997,8 @@ class TestProxyQuery(unittest.TestCase):
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
         self.assertEqual(res.headers['content-type'], 'text/html')
-        self.assertNotIn('x-object-meta-key1', res.headers)
-        self.assertNotIn('x-object-meta-key2', res.headers)
+        self.assertEqual(res.headers['x-object-meta-key1'], 'value1')
+        self.assertEqual(res.headers['x-object-meta-key2'], 'value2')
         self.assertEqual(res.body, '<html><body>Test this</body></html>')
         self.check_container_integrity(prosrv, '/v1/a/c', {})
 

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -108,19 +108,17 @@ RE_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
 TIMEOUT_GRACE = 0.5
 
 
-def merge_headers(current, new):
-    if hasattr(new, 'keys'):
-        for key in new.keys():
-            if not current[key.lower()]:
-                current[key.lower()] = str(new[key])
-            else:
-                current[key.lower()] += ',' + str(new[key])
-    else:
-        for key, value in new:
-            if not current[key.lower()]:
-                current[key.lower()] = str(value)
-            else:
-                current[key.lower()] += ',' + str(value)
+def merge_headers(final, mergeable, new):
+    key_list = mergeable.keys()
+    for key in key_list:
+        mergeable[key] = new.get(key, mergeable[key])
+        if not final.get(key):
+            final[key] = str(mergeable[key])
+        else:
+            final[key] += ',' + str(mergeable[key])
+    for key in new.keys():
+        if key not in key_list:
+            final[key] = new[key]
 
 
 def has_control_chars(line):

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -132,12 +132,13 @@ def has_control_chars(line):
     return False
 
 
-def update_metadata(request, meta_data):
+def update_metadata(request, meta_data, prefix='x-object-meta-%s'):
     if not meta_data:
         return None
     meta_count = 0
     meta_size = 0
     for key, value in meta_data.iteritems():
+        key = prefix % key
         meta_count += 1
         meta_size += len(key) + len(value)
         if len(key) > MAX_META_NAME_LENGTH:
@@ -148,7 +149,7 @@ def update_metadata(request, meta_data):
             return 'Too many metadata items; max %d' % MAX_META_COUNT
         elif meta_size > MAX_META_OVERALL_SIZE:
             return 'Total metadata too large; max %d' % MAX_META_OVERALL_SIZE
-        request.headers['x-object-meta-%s' % key] = value
+        request.headers[key] = value
 
 
 def can_run_as_daemon(node_conf, daemon_conf):

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -1,10 +1,10 @@
 from copy import deepcopy
 import re
 from hashlib import md5
-from swift.common.constraints import MAX_META_NAME_LENGTH, \
-    MAX_META_VALUE_LENGTH, MAX_META_COUNT, MAX_META_OVERALL_SIZE
+
 from swift.common.swob import Response
 from swift.common.utils import split_path, readconf
+
 
 try:
     import simplejson as json
@@ -130,26 +130,6 @@ def has_control_chars(line):
         if re.search(r"[\x01-\x1F\x7F]", line):
             return True
     return False
-
-
-def update_metadata(request, meta_data, prefix='x-object-meta-%s'):
-    if not meta_data:
-        return None
-    meta_count = 0
-    meta_size = 0
-    for key, value in meta_data.iteritems():
-        key = prefix % key
-        meta_count += 1
-        meta_size += len(key) + len(value)
-        if len(key) > MAX_META_NAME_LENGTH:
-            return 'Metadata name too long; max %d' % MAX_META_NAME_LENGTH
-        elif len(value) > MAX_META_VALUE_LENGTH:
-            return 'Metadata value too long; max %d' % MAX_META_VALUE_LENGTH
-        elif meta_count > MAX_META_COUNT:
-            return 'Too many metadata items; max %d' % MAX_META_COUNT
-        elif meta_size > MAX_META_OVERALL_SIZE:
-            return 'Total metadata too large; max %d' % MAX_META_OVERALL_SIZE
-        request.headers[key] = value
 
 
 def can_run_as_daemon(node_conf, daemon_conf):

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -42,7 +42,7 @@ from zerocloud.configparser import ClusterConfigParser
 from zerocloud.proxyquery import gunzip_iter
 
 from zerocloud.tarstream import UntarStream, TarStream, \
-    REGTYPE, BLOCKSIZE, NUL
+    REGTYPE, BLOCKSIZE, NUL, PAX_FORMAT
 import zerocloud.thread_pool as zpool
 
 try:
@@ -1031,25 +1031,29 @@ class ObjectQueryMiddleware(object):
                 if daemon_status == 1:
                     response.headers['x-zerovm-daemon'] = \
                         req.headers.get('x-zerovm-daemon', None)
-                tar_stream = TarStream()
+                tar_stream = TarStream(format=PAX_FORMAT, encoding='utf-8',
+                                       chunk_size=self.network_chunk_size)
                 resp_size = 0
                 immediate_responses = []
                 send_config = False
                 for ch in response_channels:
+                    headers = HeaderKeyDict()
                     if ch['content_type'].startswith('message/http'):
-                        self._read_cgi_response(ch, nph=True)
+                        headers = self._read_cgi_response(ch, nph=True)
                         send_config = True
                     elif ch['content_type'].startswith('message/cgi'):
-                        self._read_cgi_response(ch, nph=False)
+                        headers = self._read_cgi_response(ch, nph=False)
                         send_config = True
                     else:
                         ch['size'] = \
                             self.os_interface.path.getsize(ch['lpath'])
                     if ch['size'] < ch['min_size']:
                         continue
+                    headers = _set_pax_headers(headers, ch)
                     info = tar_stream.create_tarinfo(ftype=REGTYPE,
                                                      name=ch['device'],
-                                                     size=ch['size'])
+                                                     size=ch['size'],
+                                                     headers=headers)
                     tar_size = TarStream.get_archive_size(ch['size'])
                     resp_size += len(info) + tar_size
                     ch['info'] = info
@@ -1097,36 +1101,35 @@ class ObjectQueryMiddleware(object):
                         TarStream.get_archive_size(len(sysmap_dump))
 
                 def resp_iter(channels, chunk_size):
-                    tstream = TarStream(chunk_size=chunk_size)
                     if send_config:
-                        for chunk in tstream.serve_chunk(sysmap_info):
+                        for chunk in tar_stream.serve_chunk(sysmap_info):
                             yield chunk
-                        for chunk in tstream.serve_chunk(sysmap_dump):
+                        for chunk in tar_stream.serve_chunk(sysmap_dump):
                             yield chunk
                         blocks, remainder = divmod(len(sysmap_dump), BLOCKSIZE)
                         if remainder > 0:
                             nulls = NUL * (BLOCKSIZE - remainder)
-                            for chunk in tstream.serve_chunk(nulls):
+                            for chunk in tar_stream.serve_chunk(nulls):
                                 yield chunk
                     for ch in channels:
                         fp = open(ch['lpath'], 'rb')
                         if ch.get('offset', None):
                             fp.seek(ch['offset'])
                         reader = iter(lambda: fp.read(chunk_size), '')
-                        for chunk in tstream.serve_chunk(ch['info']):
+                        for chunk in tar_stream.serve_chunk(ch['info']):
                             yield chunk
                         for data in reader:
-                            for chunk in tstream.serve_chunk(data):
+                            for chunk in tar_stream.serve_chunk(data):
                                 yield chunk
                         fp.close()
                         os.unlink(ch['lpath'])
                         blocks, remainder = divmod(ch['size'], BLOCKSIZE)
                         if remainder > 0:
                             nulls = NUL * (BLOCKSIZE - remainder)
-                            for chunk in tstream.serve_chunk(nulls):
+                            for chunk in tar_stream.serve_chunk(nulls):
                                 yield chunk
-                    if tstream.data:
-                        yield tstream.data
+                    if tar_stream.data:
+                        yield tar_stream.data
 
                 response.app_iter = resp_iter(immediate_responses,
                                               self.network_chunk_size)
@@ -1134,6 +1137,7 @@ class ObjectQueryMiddleware(object):
                 return response
 
     def _read_cgi_response(self, ch, nph=True):
+        headers = HeaderKeyDict()
         if nph:
             fp = open(ch['lpath'], 'rb')
         else:
@@ -1147,8 +1151,9 @@ class ObjectQueryMiddleware(object):
             ch['size'] = self.os_interface.path.getsize(ch['lpath'])
             fp.close()
             self.logger.warning('Invalid message/http')
-            return
-        headers = dict(resp.getheaders())
+            return headers
+        headers['status'] = '%d %s' % (resp.status, resp.reason)
+        headers.update(resp.getheaders())
         ch['offset'] = fp.tell()
         metadata = {}
         if 'content-type' in headers:
@@ -1161,6 +1166,7 @@ class ObjectQueryMiddleware(object):
         ch['meta'] = metadata
         ch['size'] = self.os_interface.path.getsize(ch['lpath']) - ch['offset']
         fp.close()
+        return headers
 
     def __call__(self, env, start_response):
         """WSGI Application entry point for the Swift Object Server."""
@@ -1469,6 +1475,16 @@ def _channel_cleanup(response_channels):
             os.unlink(ch['lpath'])
         except OSError:
             pass
+
+
+def _set_pax_headers(headers, channel):
+    ch_headers = HeaderKeyDict({
+        'content-length': channel['size'],
+        'content-type': channel['content_type'],
+        'x-zerovm-device': channel['device']
+    })
+    headers.update(ch_headers)
+    return headers
 
 
 def filter_factory(global_conf, **local_conf):

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -30,7 +30,9 @@ from swift.proxy.server import ObjectController, ContainerController, \
     AccountController
 from swift.common.bufferedhttp import http_connect
 from swift.common.exceptions import ConnectionTimeout, ChunkReadTimeout
-from swift.common.constraints import check_utf8, MAX_FILE_SIZE
+from swift.common.constraints import check_utf8, MAX_FILE_SIZE, MAX_HEADER_SIZE, \
+    MAX_META_NAME_LENGTH, MAX_META_VALUE_LENGTH, MAX_META_COUNT, \
+    MAX_META_OVERALL_SIZE
 from swift.common.swob import Request, Response, HTTPNotFound, \
     HTTPPreconditionFailed, HTTPRequestTimeout, HTTPRequestEntityTooLarge, \
     HTTPBadRequest, HTTPUnprocessableEntity, HTTPServiceUnavailable, \
@@ -38,7 +40,7 @@ from swift.common.swob import Request, Response, HTTPNotFound, \
 from zerocloud.common import ACCESS_READABLE, ACCESS_CDR, \
     CLUSTER_CONFIG_FILENAME, NODE_CONFIG_FILENAME, TAR_MIMES, \
     POST_TEXT_OBJECT_SYSTEM_MAP, POST_TEXT_ACCOUNT_SYSTEM_MAP, \
-    merge_headers, update_metadata, DEFAULT_EXE_SYSTEM_MAP, \
+    merge_headers, DEFAULT_EXE_SYSTEM_MAP, \
     STREAM_CACHE_SIZE, parse_location, is_swift_path, \
     is_image_path, can_run_as_daemon, SwiftPath, load_server_conf, \
     expand_account_path, TIMEOUT_GRACE
@@ -72,6 +74,44 @@ def _req_content_type_property():
                     doc="Retrieve and set the request Content-Type header")
 
 Request.content_type = _req_content_type_property()
+
+
+def check_headers_metadata(new_req, headers, target_type, req):
+    prefix = 'x-%s-meta-' % target_type.lower()
+    meta_count = 0
+    meta_size = 0
+    for key, value in headers.iteritems():
+        if isinstance(value, basestring) and len(value) > MAX_HEADER_SIZE:
+            raise HTTPBadRequest(body='Header value too long: %s' %
+                                      key[:MAX_META_NAME_LENGTH],
+                                 request=req, content_type='text/plain')
+        if not key.lower().startswith(prefix):
+            continue
+        new_req.headers[key] = value
+        key = key[len(prefix):]
+        if not key:
+            raise HTTPBadRequest(body='Metadata name cannot be empty',
+                                 request=req, content_type='text/plain')
+        meta_count += 1
+        meta_size += len(key) + len(value)
+        if len(key) > MAX_META_NAME_LENGTH:
+            raise HTTPBadRequest(
+                body='Metadata name too long: %s%s' % (prefix, key),
+                request=req, content_type='text/plain')
+        elif len(value) > MAX_META_VALUE_LENGTH:
+            raise HTTPBadRequest(
+                body='Metadata value longer than %d: %s%s' % (
+                    MAX_META_VALUE_LENGTH, prefix, key),
+                request=req, content_type='text/plain')
+        elif meta_count > MAX_META_COUNT:
+            raise HTTPBadRequest(
+                body='Too many metadata items; max %d' % MAX_META_COUNT,
+                request=req, content_type='text/plain')
+        elif meta_size > MAX_META_OVERALL_SIZE:
+            raise HTTPBadRequest(
+                body='Total metadata too large; max %d'
+                     % MAX_META_OVERALL_SIZE,
+                request=req, content_type='text/plain')
 
 
 class GreenPileEx(GreenPile):
@@ -1321,12 +1361,7 @@ class ClusterController(ObjectController):
             untar_stream.update_buffer(data)
             info = untar_stream.get_next_tarinfo()
             while info:
-                if 'sysmap' == info.name:
-                    untar_stream.to_write = info.size
-                    untar_stream.offset_data = info.offset_data
-                    _load_channel_data(node, ExtractedFile(untar_stream))
-                    info = untar_stream.get_next_tarinfo()
-                    continue
+                headers = info.get_headers()
                 chan = node.get_channel(device=info.name)
                 if not chan:
                     conn.error = 'Channel name %s not found' % info.name
@@ -1337,23 +1372,23 @@ class ClusterController(ObjectController):
                         cache=[untar_stream.block[info.offset_data:]],
                         total_size=info.size))
                     resp.app_iter = app_iter
-                    resp.content_length = info.size
-                    resp.content_type = chan.content_type
+                    resp.content_length = headers['Content-Length']
+                    resp.content_type = headers['Content-Type']
+                    check_headers_metadata(resp, headers, 'object', request)
+                    if headers.get('Status'):
+                        resp.headers['status'] = headers['Status']
                     return conn
                 dest_req = Request.blank(chan.path.path,
                                          environ=request.environ,
                                          headers=request.headers)
                 dest_req.path_info = chan.path.path
                 dest_req.method = 'PUT'
-                dest_req.headers['content-length'] = info.size
+                dest_req.headers['content-length'] = headers['Content-Length']
                 untar_stream.to_write = info.size
                 untar_stream.offset_data = info.offset_data
                 dest_req.environ['wsgi.input'] = ExtractedFile(untar_stream)
-                dest_req.content_type = chan.content_type
-                error = update_metadata(dest_req, chan.meta)
-                if error:
-                    conn.error = error
-                    return conn
+                dest_req.content_type = headers['Content-Type']
+                check_headers_metadata(dest_req, headers, 'object', request)
                 dest_resp = \
                     ObjectController(self.app,
                                      chan.path.account,

--- a/zerocloud/tarstream.py
+++ b/zerocloud/tarstream.py
@@ -393,6 +393,16 @@ class TarInfo(object):
 
         return buf + self._create_header(info, USTAR_FORMAT)
 
+    def get_headers(self):
+        headers = {}
+        for key, value in self.pax_headers.items():
+            if isinstance(key, unicode):
+                key = key.encode('utf-8')
+            if isinstance(value, unicode):
+                value = value.encode('utf-8')
+            headers[key.title()] = value
+        return headers
+
     @classmethod
     def create_pax_global_header(cls, pax_headers):
         """Return the object as a pax global header block sequence.

--- a/zerocloud/tarstream.py
+++ b/zerocloud/tarstream.py
@@ -943,7 +943,7 @@ class StringBuffer:
 
 class TarStream(object):
 
-    errors = None
+    errors = 'strict'
 
     def __init__(self, tar_iter=None, path_list=None, chunk_size=65536,
                  format=DEFAULT_FORMAT, encoding=ENCODING, append=False):
@@ -968,7 +968,8 @@ class TarStream(object):
         else:
             self.data += buf
 
-    def create_tarinfo(self, path=None, ftype=None, name=None, size=None):
+    def create_tarinfo(self, path=None, ftype=None, name=None, size=None,
+                       headers=None):
         tarinfo = TarInfo()
         tarinfo.tarfile = None
         if path:
@@ -980,6 +981,8 @@ class TarStream(object):
             tarinfo.name = name
             tarinfo.size = size
         tarinfo.mtime = time.time()
+        if headers:
+            tarinfo.pax_headers = dict(headers)
         buf = tarinfo.tobuf(self.format, self.encoding, self.errors)
         return buf
 


### PR DESCRIPTION
this patch will pass as many headers as possible from the output of user script/application to the appropriate channels
it is mainly useful for channels of `message/cgi` or `message/http` type
for these channels all their output headers and their status will be passed on to the final reponse the user gets
of course it means that `message/cgi` or `message/http` channel should have no `path` defined
caveats:
- if you define clustered job and have multiple output channels without `path` their bodies will be concatenated as usual, but their headers will overwrite one another in an undefined way, beware!
- if you defined multiple `message/cgi` or `message/http` channels without path the results will be even stranger than that, beware!
