### PR TITLE
 implement simple job chaining

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
             'proxy_query=zerocloud.proxyquery:filter_factory',
             'object_query=zerocloud.objectquery:filter_factory',
             'zero_queue=zerocloud.queue:filter_factory',
+            'job_chain=zerocloud.chain:filter_factory'
         ],
     },
 )

--- a/zerocloud/chain.py
+++ b/zerocloud/chain.py
@@ -1,0 +1,88 @@
+from time import time
+from swift.common.swob import Request
+from swift.common.utils import split_path, get_logger
+from swift.common.wsgi import WSGIContext, make_subrequest, CloseableChain
+from zerocloud.proxyquery import is_zerocloud_request
+
+
+class ChainContext(WSGIContext):
+    def __init__(self, wsgi_app, version, account, middleware):
+        super(ChainContext, self).__init__(wsgi_app)
+        self.version = version
+        self.account = account
+        self.middleware = middleware
+
+    def handle_chain(self, env, start_response):
+        total_time = 0
+        while True:
+            start = time()
+            resp = self._app_call(env)
+            total_time += time() - start
+            if not self.do_chain_response(total_time):
+                self._response_headers.append(('X-Chain-Total-Time', '%.3f' %
+                                               total_time))
+                start_response(self._response_status, self._response_headers,
+                               self._response_exc_info)
+                return resp
+            # we are chaining
+            data = ''
+            bytes_transferred = 0
+            for chunk in resp:
+                data += chunk
+                bytes_transferred += len(chunk)
+                if bytes_transferred > self.middleware.zerovm_maxconfig:
+                    # we got more bytes than we expect
+                    # just stream the response to user, not gonna chain it
+                    return CloseableChain([data], resp)
+            path = '/v1/%s' % self.account
+            headers = {'X-Zerovm-Execute': '1.0',
+                       'Content-Type': 'application/json'}
+            new_req = make_subrequest(env, method='POST', path=path, body=data,
+                                      headers=headers, swift_source='chain')
+            env = new_req.environ
+
+    def do_chain_response(self, total_time):
+        content_type = zvm_exec = None
+        for h_key, val in self._response_headers:
+            if h_key.lower() == 'content-type':
+                content_type = val
+            elif h_key.lower() == 'x-zerovm-execute':
+                zvm_exec = val
+        return zvm_exec \
+            and content_type == 'application/json' \
+            and total_time < self.middleware.chain_timeout
+
+
+class ChainMiddleware(object):
+    def __init__(self, app, conf, logger=None):
+        self.app = app
+        if logger:
+            self.logger = logger
+        else:
+            self.logger = get_logger(conf, log_route='chain')
+        self.zerovm_maxconfig = int(conf.get('zerovm_maxconfig', 65536))
+        self.chain_timeout = int(conf.get('chain_timeout', 20))
+
+    def __call__(self, env, start_response):
+        req = Request(env)
+        try:
+            version, account, _rest = split_path(req.path, 2, 3, True)
+        except ValueError:
+            return self.app(env, start_response)
+        if is_zerocloud_request(version, account, req.headers):
+            context = ChainContext(self.app, version, account, self)
+            return context.handle_chain(env, start_response)
+        return self.app(env, start_response)
+
+
+def filter_factory(global_conf, **local_conf):
+    """
+    paste.deploy app factory for creating WSGI proxy apps.
+    """
+    conf = global_conf.copy()
+    conf.update(local_conf)
+
+    def chain_filter(app):
+        return ChainMiddleware(app, conf)
+
+    return chain_filter

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -575,6 +575,7 @@ class ProxyQueryMiddleware(object):
             # each request is assigned a unique k-sorted id
             # it will be used by QoS code to assign slots/priority
             req.headers['x-zerocloud-id'] = self.uid_generator.get()
+            req.headers['x-zerovm-timeout'] = self.zerovm_timeout
             res = handler(req)
             perf = time.time() - start_time
             if 'x-nexe-cdr-line' in res.headers:
@@ -675,8 +676,6 @@ class ClusterController(ObjectController):
                     str(policy_index)
             exec_request.path_info = node.path_info
             exec_request.headers['x-zerovm-access'] = node.access
-            exec_request.headers['x-zerovm-timeout'] = \
-                self.middleware.zerovm_timeout
             if node.replicate > 1:
                 container_info = self.container_info(account, container)
                 container_partition = container_info['partition']


### PR DESCRIPTION
this patch adds another middleware `ChainMiddleware`
the middleware allows rescheduling of response from previous job as a new job
for the chain to work the following statements should be true:
- response should contain `X-Zerovm-Execute: 1.0` header
- response should contain `Content-Type: application/json` header, and effectively be a json job description

you can see that the application that tries to chain something should be able to set a _response header_
which means that application MUST use `message/cgi` or `message/http` as its output channel content type
ChainMiddleware MUST be placed anywhere before ProxyQueryMiddleware in the proxy-server pipeline

example job description that can output a chained job is:

```
[
        {
            'name': 'http',
            'exec': {'path': 'swift://a/c/chainer'},
            'devices': [
                {
                    'name': 'stdout',
                    'content_type': 'message/http'
                }
            ]
        }
]
```

as you can see, stdout has no path - will be sent to user, and its content_type is `message/http`

Protection from infinite loops:
`ChainMiddleware` has a config file setting `chain_timeout` (in seconds), by default `chain_timeout = 20`.
If chain is executing more than `chain_timeout` the chain will stop and the resulting job description file will be returned to user.
