### PR TITLE
Vagrant scripts for dev environment

### DIFF
--- a/contrib/vagrant/.gitignore
+++ b/contrib/vagrant/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -1,0 +1,39 @@
+## Installation
+
+### Ubuntu Linux 12.04
+
+1. Install VirtualBox:
+
+    `sudo apt-get install virtualbox`
+
+
+2. Install the latest version of Vagrant:
+
+```bash
+# 64-bit
+wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3_x86_64.deb
+sudo dpkg -i vagrant_1.6.3_x86_64.deb
+# 32-bit
+wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3_i686.deb
+sudo dpkg -i vagrant_1.6.3_i686.deb
+```
+
+For a list of all releases of Vagrant, see https://dl.bintray.com/mitchellh/vagrant/.
+
+3. Change into this directory (the one with `Vagrantfile`).
+
+4. Run Vagrant:
+
+    `vagrant up`
+
+
+### OSX
+
+1. Download and install VirtualBox and Vagrant from .dmgs. See https://www.virtualbox.org/wiki/Downloads
+   and https://www.vagrantup.com/downloads.
+
+2. Change into this directory (the one with `Vagrantfile`).
+
+3. Run Vagrant:
+
+    `vagrant up`

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -1,0 +1,24 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "hashicorp/precise64"
+  config.vm.provision "shell", privileged: false, path: "bootstrap.sh"
+
+  # Port forwarding
+  # Swift:
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+  # Keystone:
+  config.vm.network "forwarded_port", guest: 5000, host: 5000
+  # Keystone admin:
+  config.vm.network "forwarded_port", guest: 35357, host: 35357
+
+end

--- a/contrib/vagrant/bootstrap.sh
+++ b/contrib/vagrant/bootstrap.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+sudo apt-get update
+sudo apt-get install python-software-properties --yes --force-yes
+# Add PPA for ZeroVM packages
+sudo add-apt-repository ppa:zerovm-ci/zerovm-latest -y
+sudo apt-get update
+sudo apt-get install git zerovm-cli zpm --yes --force-yes
+
+
+###
+# DevStack
+git clone https://github.com/openstack-dev/devstack.git $HOME/devstack
+cd $HOME/devstack
+touch local.conf
+read -d '' LOCAL_CONF << EOF
+[[local|localrc]]
+ADMIN_PASSWORD=admin
+HOST_IP=127.0.0.1
+disable_all_services
+enable_service key mysql s-proxy s-object s-container s-account
+EOF
+echo "$LOCAL_CONF" >> local.conf
+./stack.sh
+
+###
+# ZeroCloud
+git clone https://github.com/zerovm/zerocloud.git $HOME/zerocloud
+cd $HOME/zerocloud
+sudo python setup.py install
+
+###
+# Python system image for ZeroCloud/ZeroVM
+sudo mkdir /usr/share/zerovm
+cd /usr/share/zerovm
+sudo wget http://packages.zerovm.org/zerovm-samples/python.tar
+
+###
+# Add ZeroCloud middleware to swift config
+# This includes setting up the cross-compiled python
+# distribution for ZeroVM.
+python /vagrant/configure_swift.py

--- a/contrib/vagrant/configure_swift.py
+++ b/contrib/vagrant/configure_swift.py
@@ -1,0 +1,43 @@
+from ConfigParser import ConfigParser
+
+
+def inject_before(some_list, item, target):
+    for i, each in enumerate(some_list):
+        if each == target:
+            some_list.insert(i, item)
+            break
+    else:
+        # just append to the list:
+        some_list.append(item)
+
+
+if __name__ == '__main__':
+    cp = ConfigParser()
+    cp.read('/etc/swift/object-server/1.conf')
+    cp.add_section('filter:object-query')
+    cp.set('filter:object-query', 'use',
+           value='egg:zerocloud#object_query')
+    cp.set('filter:object-query', 'zerovm_sysimage_devices',
+           value='python2.7 /usr/share/zerovm/python.tar')
+
+    pipeline = cp.get('pipeline:main', 'pipeline').split()
+    inject_before(pipeline, 'object-query', 'object-server')
+    cp.set('pipeline:main', 'pipeline', value=' '.join(pipeline))
+
+    with open('/etc/swift/object-server/1.conf', 'w') as fp:
+        cp.write(fp)
+
+    cp = ConfigParser()
+    cp.read('/etc/swift/proxy-server.conf')
+    cp.add_section('filter:proxy-query')
+    cp.set('filter:proxy-query', 'use',
+           value='egg:zerocloud#proxy_query')
+    cp.set('filter:proxy-query', 'zerovm_sysimage_devices',
+           value='python2.7 /usr/share/zerovm/python.tar')
+
+    pipeline = cp.get('pipeline:main', 'pipeline').split()
+    inject_before(pipeline, 'proxy-query', 'proxy-server')
+    cp.set('pipeline:main', 'pipeline', value=' '.join(pipeline))
+
+    with open('/etc/swift/proxy-server.conf', 'w') as fp:
+        cp.write(fp)


### PR DESCRIPTION
While I was at EuroPython last week, I put together this Vagrant script to help people set up their Devstack/ZeroCloud environment. It may need some more work and better documentation, but it's a start.

I did this because I found it tedious and error-prone to do everything by hand (see `doc/Hacking.md`).

Note: If you're running Linux in VirtualBox or on a Rackspace cloud server, the default virt backend for Vagrant (VirtualBox) will not work.
