### PR TITLE
produce better errors in RestController

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -3453,6 +3453,14 @@ class TestProxyQuery(unittest.TestCase):
             req.method = method
             req.headers['x-zerovm-execute'] = 'open/1.0'
             res = req.get_response(prosrv)
+            self.assertEqual(res.status_int, 412)
+        for method in ['POST', 'HEAD', 'DELETE', 'PUT']:
+            req = self.zerovm_request()
+            req.body = ''
+            req.method = method
+            req.headers['x-zerovm-execute'] = 'open/1.0'
+            req.path_info = '/v1/a/c/o'
+            res = req.get_response(prosrv)
             self.assertEqual(res.status_int, 501)
 
     def test_setting_nexe_headers(self):


### PR DESCRIPTION
do not invoke RestController if the request url is not an object url
fixup query string in RestController in such a way that is actually visible
