### PR TITLE
change CGI environment for local objects

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -1046,11 +1046,12 @@ class TestProxyQuery(unittest.TestCase):
         self.assertEqual(res.headers['x-object-meta-key2'], 'val2')
         self.assertEqual(res.headers['content-type'], 'application/x-pickle')
         out = pickle.loads(res.body)
-        self.assertIn('name=CONTENT_TYPE, value=application/x-pickle', out)
-        self.assertIn('name=HTTP_X_OBJECT_META_KEY1, value=val1', out)
-        self.assertIn('name=HTTP_X_OBJECT_META_KEY2, value=val2', out)
-        self.assertIn('name=DOCUMENT_ROOT, value=/dev/stdout', out)
-        self.assertIn('name=PATH_INFO, value=/a/c/o3', out)
+        self.assertIn('name=LOCAL_CONTENT_TYPE, value=application/x-pickle',
+                      out)
+        self.assertIn('name=LOCAL_HTTP_X_OBJECT_META_KEY1, value=val1', out)
+        self.assertIn('name=LOCAL_HTTP_X_OBJECT_META_KEY2, value=val2', out)
+        self.assertIn('name=LOCAL_DOCUMENT_ROOT, value=/dev/stdout', out)
+        self.assertIn('name=LOCAL_PATH_INFO, value=/a/c/o3', out)
         content_length = res.content_length
         conf = [
             {
@@ -1075,14 +1076,16 @@ class TestProxyQuery(unittest.TestCase):
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
         out = pickle.loads(res.body)
-        self.assertIn('name=CONTENT_TYPE, value=application/x-pickle', out)
-        self.assertIn('name=HTTP_X_OBJECT_META_KEY1, value=val1', out)
-        self.assertIn('name=HTTP_X_OBJECT_META_KEY2, value=val2', out)
-        self.assertIn('name=DOCUMENT_ROOT, value=/dev/stdin', out)
-        self.assertIn('name=PATH_INFO, value=/a/c/o3', out)
-        self.assertIn('name=CONTENT_LENGTH, value=%d' % content_length, out)
+        self.assertIn('name=LOCAL_CONTENT_TYPE, value=application/x-pickle',
+                      out)
+        self.assertIn('name=LOCAL_HTTP_X_OBJECT_META_KEY1, value=val1', out)
+        self.assertIn('name=LOCAL_HTTP_X_OBJECT_META_KEY2, value=val2', out)
+        self.assertIn('name=LOCAL_DOCUMENT_ROOT, value=/dev/stdin', out)
+        self.assertIn('name=LOCAL_PATH_INFO, value=/a/c/o3', out)
+        self.assertIn('name=LOCAL_CONTENT_LENGTH, value=%d' % content_length,
+                      out)
         self.assertIn('name=SCRIPT_NAME, value=http', out)
-        self.assertIn('name=SCRIPT_FILENAME, value=/a/c/exe2', out)
+        self.assertIn('name=SCRIPT_FILENAME, value=swift://a/c/exe2', out)
         self.assertIn('name=QUERY_STRING, value=%s' % req.query_string, out)
         self.check_container_integrity(prosrv, '/v1/a/c', {})
         conf = [
@@ -1110,14 +1113,16 @@ class TestProxyQuery(unittest.TestCase):
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 200)
         out = pickle.loads(res.body)
-        self.assertIn('name=CONTENT_TYPE, value=application/x-pickle', out)
-        self.assertIn('name=HTTP_X_OBJECT_META_KEY1, value=val1', out)
-        self.assertIn('name=HTTP_X_OBJECT_META_KEY2, value=val2', out)
-        self.assertIn('name=DOCUMENT_ROOT, value=/dev/stdin', out)
-        self.assertIn('name=PATH_INFO, value=/a/c/o3', out)
-        self.assertIn('name=CONTENT_LENGTH, value=%d' % content_length, out)
+        self.assertIn('name=LOCAL_CONTENT_TYPE, value=application/x-pickle',
+                      out)
+        self.assertIn('name=LOCAL_HTTP_X_OBJECT_META_KEY1, value=val1', out)
+        self.assertIn('name=LOCAL_HTTP_X_OBJECT_META_KEY2, value=val2', out)
+        self.assertIn('name=LOCAL_DOCUMENT_ROOT, value=/dev/stdin', out)
+        self.assertIn('name=LOCAL_PATH_INFO, value=/a/c/o3', out)
+        self.assertIn('name=LOCAL_CONTENT_LENGTH, value=%d' % content_length,
+                      out)
         self.assertIn('name=SCRIPT_NAME, value=http_script', out)
-        self.assertIn('name=SCRIPT_FILENAME, value=/a/c/exe2', out)
+        self.assertIn('name=SCRIPT_FILENAME, value=swift://a/c/exe2', out)
         self.check_container_integrity(prosrv, '/v1/a/c', {})
 
     def test_QUERY_GET_response(self):

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -348,7 +348,7 @@ class ZvmNode(object):
         self.env['SERVER_SOFTWARE'] = 'zerocloud'
         self.env['GATEWAY_INTERFACE'] = 'CGI/1.1'
         self.env['SCRIPT_NAME'] = self.exe_name or self.name
-        self.env['SCRIPT_FILENAME'] = self.exe.path
+        self.env['SCRIPT_FILENAME'] = self.exe
         if cgi_env:
             self.env.update(cgi_env)
         # we need to show the real host name, if possible

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -675,39 +675,41 @@ class ClusterConfigParser(object):
                     metadata = local_object['meta']
                     content_type = metadata.get('Content-Type',
                                                 'application/octet-stream')
-                    env += ENV_ITEM % ('CONTENT_LENGTH', local_object['size'])
-                    env += ENV_ITEM % ('CONTENT_TYPE',
+                    env += ENV_ITEM % ('LOCAL_CONTENT_LENGTH', local_object[
+                        'size'])
+                    env += ENV_ITEM % ('LOCAL_CONTENT_TYPE',
                                        quote_for_env(content_type))
                     for k, v in metadata.iteritems():
                         meta = k.upper()
                         if meta.startswith('X-OBJECT-META-'):
                             env += ENV_ITEM \
-                                % ('HTTP_%s' % meta.replace('-', '_'),
+                                % ('LOCAL_HTTP_%s' % meta.replace('-', '_'),
                                    quote_for_env(v))
                             continue
                         for hdr in ['X-TIMESTAMP', 'ETAG', 'CONTENT-ENCODING']:
                             if hdr in meta:
                                 env += ENV_ITEM \
-                                    % ('HTTP_%s' % meta.replace('-', '_'),
+                                    % ('LOCAL_HTTP_%s' % meta.replace('-',
+                                                                      '_'),
                                         quote_for_env(v))
                                 break
                 elif local_object['access'] & ACCESS_WRITABLE:
                     content_type = local_object.get('content_type',
                                                     'application/octet-stream')
-                    env += ENV_ITEM % ('CONTENT_TYPE',
+                    env += ENV_ITEM % ('LOCAL_CONTENT_TYPE',
                                        quote_for_env(content_type))
                     meta = local_object.get('meta', None)
                     if meta:
                         for k, v in meta.iteritems():
                             env += ENV_ITEM \
-                                % ('HTTP_X_OBJECT_META_%s'
+                                % ('LOCAL_HTTP_X_OBJECT_META_%s'
                                    % k.upper().replace('-', '_'),
                                     quote_for_env(v))
-                env += ENV_ITEM % ('DOCUMENT_ROOT',
+                env += ENV_ITEM % ('LOCAL_DOCUMENT_ROOT',
                                    '/dev/%s'
                                    % local_object['device'])
-                config['env']['REQUEST_METHOD'] = 'POST'
-                config['env']['PATH_INFO'] = local_object['path_info']
+                config['env']['LOCAL_OBJECT'] = 'on'
+                config['env']['LOCAL_PATH_INFO'] = local_object['path_info']
             for k, v in config['env'].iteritems():
                 if v:
                     env += ENV_ITEM % (k, quote_for_env(v))


### PR DESCRIPTION
CGI requires passing the headers from request to the environment
up until now the local Swift object metadata was exposed through regular CGI headers (like CONTENT_LENGTH or HTTP_ETAG)
to give way to better CGI support all these headers were renamed with prefix `LOCAL_`
right now the following headers are exposed that way:

LOCAL_OBJECT - if exists, there is a local object present, if not - no other LOCAL_\* vars will be present
LOCAL_CONTENT_LENGTH - size of a file
LOCAL_CONTENT_TYPE- content type of that object
LOCAL_PATH_INFO - path to the object in the format of `/account/container/obj`
LOCAL_HTTP_ETAG - etag for object (md5)
LOCAL_HTTP_X_TIMESTAMP - creation timestamp
LOCAL_HTTP_CONTENT_ENCODING - content encoding, if present
LOCAL_DOCUMENT_ROOT - path to object inside the instance `/dev/device`
LOCAL_HTTP_X_OBJECT_META_\* - user metadata headers for object
