### PR TITLE
vagrant/bootstrap.sh: silence wget output

### DIFF
--- a/contrib/vagrant/bootstrap.sh
+++ b/contrib/vagrant/bootstrap.sh
@@ -33,7 +33,7 @@ sudo python setup.py install
 # Python system image for ZeroCloud/ZeroVM
 sudo mkdir /usr/share/zerovm
 cd /usr/share/zerovm
-sudo wget http://packages.zerovm.org/zerovm-samples/python.tar
+sudo wget -q http://packages.zerovm.org/zerovm-samples/python.tar
 
 ###
 # Add ZeroCloud middleware to swift config


### PR DESCRIPTION
The way vagrant streams the output of the progress indication of wget is
super annoying. So this adds the -q flag to reduce the noise.
