### PR TITLE
vagrant: add zerocloudrc

### DIFF
--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -37,3 +37,10 @@ For a list of all releases of Vagrant, see https://dl.bintray.com/mitchellh/vagr
 3. Run Vagrant:
 
     `vagrant up`
+
+## Client configuration
+
+You can use `python-swiftclient` and `zvm/zpm` with this vagrant box. To set
+the needed environment variables, just do:
+
+    `source zerocloudrc`

--- a/contrib/vagrant/zerocloudrc
+++ b/contrib/vagrant/zerocloudrc
@@ -1,0 +1,6 @@
+export OS_REGION_NAME=RegionOne
+export OS_IDENTITY_API_VERSION=2.0
+export OS_PASSWORD=admin
+export OS_AUTH_URL=http://127.0.0.1:5000/v2.0
+export OS_USERNAME=admin
+export OS_TENANT_NAME=demo


### PR DESCRIPTION
This file contains the necessary environment variables to use swift and
zpm clients with the machine created by this vagrant script. Just
`source zerocloudrc` to use it.
