### PR TITLE
correctly pass request payload to any type of job

### DIFF
--- a/test/unit/nvram_parser.py
+++ b/test/unit/nvram_parser.py
@@ -1,0 +1,157 @@
+from ConfigParser import ConfigParser, MissingSectionHeaderError, ParsingError
+import sys
+import re
+
+__version__ = "1.0"
+
+try:
+    from collections import OrderedDict as _default_dict
+except ImportError:
+    # fallback for setup.py which hasn't yet built _collections
+    _default_dict = dict
+
+DEFAULTSECT = "DEFAULT"
+
+
+class NvramParser(ConfigParser):
+    def __init__(self, defaults=None, dict_type=_default_dict,
+                 allow_no_value=False):
+        ConfigParser.__init__(self, defaults=defaults,
+                              dict_type=dict_type,
+                              allow_no_value=allow_no_value)
+        self._envcre = re.compile(
+            r'name\s*(?P<vi>[=])\s*(?P<option>[^,]*),\s*'
+            r'value\s*=\s*(?P<value>.*)$'
+        )
+        self._envvre = re.compile(r'\\x2c')
+
+    def _read(self, fp, fpname):
+        """Parse a sectioned setup file.
+
+        The sections in setup file contains a title line at the top,
+        indicated by a name in square brackets (`[]'), plus key/value
+        options lines, indicated by `name: value' format lines.
+        Continuations are represented by an embedded newline then
+        leading whitespace.  Blank lines, lines beginning with a '#',
+        and just about everything else are ignored.
+        """
+        cursect = None                        # None, or a dictionary
+        optname = None
+        lineno = 0
+        e = None                              # None, or an exception
+        while True:
+            line = fp.readline()
+            if not line:
+                break
+            lineno += 1
+            # comment or blank line?
+            if line.strip() == '' or line[0] in '#;':
+                continue
+            if line.split(None, 1)[0].lower() == 'rem' and line[0] in "rR":
+                # no leading whitespace
+                continue
+                # continuation line?
+            if line[0].isspace() and cursect is not None and optname:
+                value = line.strip()
+                if value:
+                    cursect[optname].append(value)
+            # a section header or option header?
+            else:
+                # is it a section header?
+                mo = self.SECTCRE.match(line)
+                if mo:
+                    sectname = mo.group('header')
+                    if sectname in self._sections:
+                        cursect = self._sections[sectname]
+                    elif sectname == DEFAULTSECT:
+                        cursect = self._defaults
+                    else:
+                        cursect = self._dict()
+                        cursect['__name__'] = sectname
+                        self._sections[sectname] = cursect
+                        # So sections can't start with a continuation line
+                    optname = None
+                # no section header in the file?
+                elif cursect is None:
+                    raise MissingSectionHeaderError(fpname, lineno, line)
+                # an option line?
+                else:
+                    if 'env' in cursect['__name__']:
+                        mo = self._envcre.match(line)
+                    else:
+                        mo = self._optcre.match(line)
+                    if mo:
+                        optname, vi, optval = mo.group('option', 'vi', 'value')
+                        optname = self.optionxform(optname.rstrip())
+                        # This check is fine because the OPTCRE cannot
+                        # match if it would set optval to None
+                        if optval is not None:
+                            optval = self._envvre.sub(',', optval).strip()
+                            # allow empty values
+                            if optval == '""':
+                                optval = ''
+                            cursect[optname] = [optval]
+                        else:
+                            # valueless option handling
+                            cursect[optname] = optval
+                    else:
+                        # a non-fatal parsing error occurred.  set up the
+                        # exception but keep going. the exception will be
+                        # raised at the end of the file and will contain a
+                        # list of all bogus lines
+                        if not e:
+                            e = ParsingError(fpname)
+                        e.append(lineno, repr(line))
+                        # if any parsing errors occurred, raise an exception
+        if e:
+            raise e
+
+        # join the multi-line values collected while reading
+        all_sections = [self._defaults]
+        all_sections.extend(self._sections.values())
+        for options in all_sections:
+            for name, val in options.items():
+                if isinstance(val, list):
+                    options[name] = '\n'.join(val)
+
+
+def readconf(conffile, section_name=None, defaults=None):
+    """
+    Read config file and return config items as a dict
+
+    :param conffile: path to config file, or a file-like object (hasattr
+                     readline)
+    :param section_name: config section to read (will return all sections if
+                     not defined)
+    :param defaults: dict of default values to pre-populate the config with
+    :returns: dict of config items
+    """
+    if defaults is None:
+        defaults = {}
+    c = NvramParser(defaults)
+    c.optionxform = str
+
+    if hasattr(conffile, 'readline'):
+        c.readfp(conffile)
+    else:
+        if not c.read(conffile):
+            print "Unable to read config file %s" % conffile
+            sys.exit(1)
+    if section_name:
+        if c.has_section(section_name):
+            conf = dict(c.items(section_name))
+        else:
+            return {}
+    else:
+        conf = {}
+        for s in c.sections():
+            conf.update({s: dict(c.items(s))})
+    return conf
+
+
+def read_env(nvram_file):
+    return readconf(nvram_file, section_name='env')
+
+if __name__ == '__main__':
+    import json
+    print json.dumps(read_env(sys.argv[1]), indent=2)

--- a/test/unit/zerovm_mock.py
+++ b/test/unit/zerovm_mock.py
@@ -8,6 +8,7 @@ import cPickle as pickle
 from time import sleep
 from argparse import ArgumentParser
 from eventlet import GreenPool, listen
+from nvram_parser import read_env
 
 try:
     import simplejson as json
@@ -296,6 +297,7 @@ except EOFError:
 except Exception:
     errdump(1, valid, 0, mnfst.Etag, accounting, 'Std files I/O error')
 
+zvm_environ = read_env(mnfst.nvram['path'])
 od = ''
 try:
     od = str(eval_as_function(exe))

--- a/zerocloud/chain.py
+++ b/zerocloud/chain.py
@@ -14,6 +14,9 @@ class ChainContext(WSGIContext):
 
     def handle_chain(self, env, start_response):
         total_time = 0
+        env['chain.input'] = env.get('wsgi.input')
+        env['chain.input_size'] = env.get('CONTENT_LENGTH', 0)
+        env['chain.input_type'] = env.get('CONTENT_TYPE')
         while True:
             start = time()
             resp = self._app_call(env)
@@ -39,6 +42,9 @@ class ChainContext(WSGIContext):
                        'Content-Type': 'application/json'}
             new_req = make_subrequest(env, method='POST', path=path, body=data,
                                       headers=headers, swift_source='chain')
+            new_req.environ['chain.input'] = env['chain.input']
+            new_req.environ['chain.input_size'] = env['chain.input_size']
+            new_req.environ['chain.input_type'] = env['chain.input_type']
             env = new_req.environ
 
     def do_chain_response(self, total_time):

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -298,6 +298,7 @@ class ZvmNode(object):
         self.attach = attach
         self.access = ''
         self.exe_name = exe_name
+        self.data_in = False
 
     def copy(self, id, name=None):
         newnode = deepcopy(self)

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -293,6 +293,8 @@ class ClusterConfigParser(object):
 
                     read_group = False
                     for chan in read_list:
+                        needs_data_in = (not chan.path
+                                         and chan.device == 'stdin')
                         if is_swift_path(chan.path) \
                                 and '*' in chan.path.path:
                             read_group = True
@@ -316,9 +318,13 @@ class ClusterConfigParser(object):
                                     new_node = self._get_or_create_node(
                                         zvm_node, index=i)
                                     new_node.add_channel(channel=chan)
+                                    if needs_data_in:
+                                        new_node.data_in = True
                             else:
                                 new_node = self._get_or_create_node(zvm_node)
                                 new_node.add_channel(channel=chan)
+                                if needs_data_in:
+                                        new_node.data_in = True
                     for chan in write_list:
                         if chan.path and is_swift_path(chan.path):
                             if '*' in chan.path.url:


### PR DESCRIPTION
this patch makes it possible to pass arbitrary payload (of POST or PUT) into the zerovm application(s)
it is an improvement on b36559a1e5ceaccce9b250f2c3f87f1c3b84371b
fixed things are:
- correclty pass payload to chained jobs
- better handle job descriptions that expect payload (faster checks)
- generalize payload handling in ChainMiddleware
- correctly handle crippled case where no ChainMiddleware is present
- improve test framework to support CGI env variables

all of the above is quite coupled, that's why I use a single commit here

the main idea is simple: original `env['wsgi.input']` is stored as another variable `env['chain.input']`
after chained job or other middleware overwrites or alters `env['wsgi.input']` the original input is still available under `env['chain.input']`
because `env['chain.input']` is just a pointer when some job wants to read from it we just check if it was not consumed previously and then give it to the job
each job in chain can partially consume input, but obvioulsy cannot restore it after it was consumed
