### PR TITLE
implement all REST services

### DIFF
--- a/test/unit/zerovm_mock.py
+++ b/test/unit/zerovm_mock.py
@@ -235,9 +235,9 @@ for fname, device, type, tag, rd, rd_byte, wr, wr_byte \
     if net_device:
         mnfst.channels[device]['path'] = '/dev/null'
     stddev.pop(device, 0)
-    if device == '/dev/stdin' or device == '/dev/input':
+    if device == '/dev/stdin':
         mnfst.input = mnfst.channels[device]
-    elif device == '/dev/stdout' or device == '/dev/output':
+    elif device == '/dev/stdout':
         mnfst.output = mnfst.channels[device]
     elif device == '/dev/stderr':
         mnfst.err = mnfst.channels[device]

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -1451,8 +1451,8 @@ def _set_pax_headers(headers, channel):
         'content-type': channel['content_type'],
         'x-zerovm-device': channel['device']
     })
-    headers.update(ch_headers)
-    return headers
+    ch_headers.update(headers)
+    return ch_headers
 
 
 def filter_factory(global_conf, **local_conf):


### PR DESCRIPTION
all REST srvice endpoints are implemented
you can HEAD, GET, POST, PUT and DELETE
although you cannot delete objects in Swift as a result of a DELETE, but you can do any other "RESTful" thing there
fixed the following:
- better precedense of headers, usually needed for HEAD, which should sometimes output same headers as GET but with no body
- status handling, `message/cgi` and `message/http` responses should be able to overwrite HTTP status

and as a consequence you can now shoot yourself in the foot by using `Content-Length` with no content and other strange constructs
