### PR TITLE
Improve REST API

### DIFF
--- a/doc/RESTServices.md
+++ b/doc/RESTServices.md
@@ -2,6 +2,8 @@
 
 ## Requests
 
+### Open requests
+
 To request a REST service endpoint the following request format can be used:
 
     <METHOD> /open/<account>/<container>/<zerovm app path>?<query string>
@@ -19,10 +21,33 @@ If you have a trouble using `/open/...` endpoint you can use standard
 `X-Auth-Storage-Url` but will have to set additional header: 
 `X-Zerovm-Execute: open/1.0`
 
+### Api requests
+
+To request a REST service endpoint the following request format can be used:
+
+    <METHOD> /api/<account>/<container>/<arbitrary path>?<query string>
+
+Where:
+ 
+- `<METHOD>` can be: `GET`, `HEAD`, `POST`, `PUT`, `DELETE`
+- `<account>` is the account name from `X-Auth-Storage-Url`
+- `<container>` is the container name
+- `<arbitrary path>` is the REST url that you will be able to use in your 
+application, `/<account>/<container>/<arbitrary path>` will be available as 
+`PATH_INFO` environment variable
+- `<query string>` is the request query string
+
+If you have a trouble using `/api/...` endpoint you can use standard 
+`X-Auth-Storage-Url` but will have to set additional header: 
+`X-Zerovm-Execute: api/1.0`
+
 ## How does it work?
 
 Your application will be invoked by fetching the `boot/system.map` from the 
 application archive and executing a job stored there.
+
+In case of Api request not only application archives could be used but also 
+any json object that adheres to servlet format (see `doc/Servlets.md`)
 
 Your application will get the `QUERY_STRING` and all other CGI-like 
 environment variables set in the environment. Including `REQUEST_METHOD`, 

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -53,7 +53,7 @@ from zerocloud.tarstream import StringBuffer, UntarStream, \
 from zerocloud.thread_pool import Zuid
 
 
-ZEROVM_COMMANDS = ['open']
+ZEROVM_COMMANDS = ['open', 'api']
 ZEROVM_EXECUTE = 'x-zerovm-execute'
 
 try:
@@ -588,6 +588,11 @@ class ProxyQueryMiddleware(object):
                 return RestController(self.app, account, container, obj, self,
                                       version)
             return None
+        elif version == 'api/1.0':
+            if container:
+                return ApiController(self.app, account, container, obj, self,
+                                     version)
+            return None
         return ClusterController(self.app, account, container, obj, self,
                                  version)
 
@@ -860,6 +865,7 @@ class ClusterController(ObjectController):
         return final_response
 
     def read_system_map(self, read_iter, chunk_size, content_type, req):
+        upload_expiration = time.time() + self.middleware.max_upload_time
         try:
             if content_type in ['application/x-gzip']:
                 read_iter = gunzip_iter(read_iter, chunk_size)
@@ -868,6 +874,8 @@ class ClusterController(ObjectController):
             untar_stream = UntarStream(read_iter, path_list)
             for chunk in untar_stream:
                 req.bytes_transferred += len(chunk)
+                if time.time() > upload_expiration:
+                    raise HTTPRequestTimeout(request=req)
         except (ReadError, zlib.error):
             raise HTTPUnprocessableEntity(
                 request=req,
@@ -894,13 +902,32 @@ class ClusterController(ObjectController):
                 data_resp.nodes = []
         return data_resp
 
+    def read_json_job(self, req, req_iter):
+        etag = md5()
+        upload_expiration = time.time() + self.middleware.max_upload_time
+        for chunk in req_iter:
+            req.bytes_transferred += len(chunk)
+            if time.time() > upload_expiration:
+                raise HTTPRequestTimeout(request=req)
+            if req.bytes_transferred > \
+                    self.middleware.zerovm_maxconfig:
+                raise HTTPRequestEntityTooLarge(request=req)
+            etag.update(chunk)
+            self.cluster_config += chunk
+        if 'content-length' in req.headers and \
+                int(req.headers['content-length']) != req.bytes_transferred:
+            raise HTTPClientDisconnect(request=req,
+                                       body='application/json '
+                                            'POST unfinished')
+        etag = etag.hexdigest()
+        if 'etag' in req.headers and req.headers['etag'].lower() != etag:
+            raise HTTPUnprocessableEntity(request=req)
+
     def post_job(self, req):
         chunk_size = self.middleware.network_chunk_size
         if 'content-type' not in req.headers:
             return HTTPBadRequest(request=req,
                                   body='Must specify Content-Type')
-        upload_expiration = time.time() + self.middleware.max_upload_time
-        etag = md5()
         rdata = req.environ['wsgi.input']
         req_iter = iter(lambda: rdata.read(chunk_size), '')
         data_resp = None
@@ -970,24 +997,7 @@ class ClusterController(ObjectController):
         elif req_content_type in 'application/json':
             # System map was sent as a POST body
             if not self.cluster_config:
-                for chunk in req_iter:
-                    req.bytes_transferred += len(chunk)
-                    if time.time() > upload_expiration:
-                        return HTTPRequestTimeout(request=req)
-                    if req.bytes_transferred > \
-                            self.middleware.zerovm_maxconfig:
-                        return HTTPRequestEntityTooLarge(request=req)
-                    etag.update(chunk)
-                    self.cluster_config += chunk
-                if 'content-length' in req.headers and \
-                   int(req.headers['content-length']) != req.bytes_transferred:
-                    return HTTPClientDisconnect(request=req,
-                                                body='application/json '
-                                                     'POST unfinished')
-                etag = etag.hexdigest()
-                if 'etag' in req.headers and\
-                   req.headers['etag'].lower() != etag:
-                    return HTTPUnprocessableEntity(request=req)
+                self.read_json_job(req, req_iter)
             try:
                 cluster_config = json.loads(self.cluster_config)
             except Exception:
@@ -1607,6 +1617,8 @@ class ClusterController(ObjectController):
 
 class RestController(ClusterController):
 
+    config_path = None
+
     def _get_content_config(self, req, content_type):
         req.template = None
         cont = self.middleware.zerovm_registry_path
@@ -1692,6 +1704,7 @@ class RestController(ClusterController):
                 self.cluster_config = config
                 return None
         config_req = req.copy_get()
+        config_req.path_info = config_path.path
         config_req.query_string = None
         buffer_length = self.middleware.zerovm_maxconfig * 2
         config_req.range = 'bytes=0-%d' % (buffer_length - 1)
@@ -1715,6 +1728,7 @@ class RestController(ClusterController):
                     memcache_key,
                     self.cluster_config,
                     time=float(self.middleware.zerovm_cache_config_timeout))
+        self.config_path = config_path
         return None
 
     def handle_request(self, req):
@@ -1726,7 +1740,7 @@ class RestController(ClusterController):
         # if we successfully got config, we know that we have a zapp in hand
         if self.cluster_config:
             self.cgi_env = self.create_cgi_env(req)
-            req.headers['x-zerovm-source'] = swift_path.url
+            req.headers['x-zerovm-source'] = self.config_path.url
             req.method = 'POST'
             return self.post_job(req)
         return None
@@ -1784,6 +1798,57 @@ class RestController(ClusterController):
         if obj_req.method in 'GET':
             self.exe_resp = obj_resp
         return self.post_job(post_req)
+
+
+class ApiController(RestController):
+
+    def load_config(self, req, config_path):
+        memcache_client = cache_from_env(req.environ)
+        memcache_key = 'zvmapp' + config_path.path
+        if memcache_client:
+            config = memcache_client.get(memcache_key)
+            if config:
+                self.cluster_config = config
+                return None
+        container_info = self.container_info(self.account_name,
+                                             self.container_name, req)
+        source = container_info['meta'].get('rest-endpoint')
+        if not source:
+            raise HTTPNotFound(request=req,
+                               body='No API endpoint configured for '
+                                    'container %s' % self.container_name)
+        config_path = parse_location(unquote(source))
+        config_req = req.copy_get()
+        config_req.path_info = config_path.path
+        config_req.query_string = None
+        buffer_length = self.middleware.zerovm_maxconfig * 2
+        config_req.range = 'bytes=0-%d' % (buffer_length - 1)
+        config_resp = ObjectController(
+            self.app,
+            self.account_name,
+            self.container_name,
+            self.object_name).GET(config_req)
+        if config_resp.status_int == HTTP_REQUESTED_RANGE_NOT_SATISFIABLE:
+            return None
+        if not is_success(config_resp.status_int) or \
+                config_resp.content_length > buffer_length:
+            return config_resp
+        if config_resp.content_type in TAR_MIMES + ['application/x-gzip']:
+            chunk_size = self.middleware.network_chunk_size
+            config_req.bytes_transferred = 0
+            self.read_system_map(config_resp.app_iter, chunk_size,
+                                 config_resp.content_type, config_req)
+        elif config_resp.content_type in ['application/json']:
+            config_req.bytes_transferred = 0
+            config_req.content_length = config_resp.content_length
+            self.read_json_job(config_req, config_resp.app_iter)
+        if memcache_client and self.cluster_config:
+            memcache_client.set(
+                memcache_key,
+                self.cluster_config,
+                time=float(self.middleware.zerovm_cache_config_timeout))
+        self.config_path = config_path
+        return None
 
 
 def _load_channel_data(node, extracted_file):


### PR DESCRIPTION
 add new ApiController

the new controller will answer to the `/api/...` urls
using these you can configure even more generic REST interfaces at the expense of losing a container identity.
if you set up `X-Container-Meta-Rest-Endpoint` on the container to a `swift://` url and use the `/api/...` path info
the application or job description will be loaded from that url and executed instead of usual container operation
the original storage-related operations will still be available under `/v1/...` url
