### PR TITLE
fix leaking of unneeded headers to applications

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -1120,6 +1120,19 @@ class TestProxyQuery(unittest.TestCase):
         self.assertIn('name=SCRIPT_NAME, value=http_script', out)
         self.assertIn('name=SCRIPT_FILENAME, value=swift://a/c/exe2', out)
         self.check_container_integrity(prosrv, '/v1/a/c', {})
+        req = self.zerovm_request()
+        req.body = conf
+        req.headers['x-auth-token'] = 't'
+        req.headers['x-storage-token'] = 't'
+        req.headers['cookie'] = 'secret'
+        req.headers['x-backend-data'] = 'internal_data'
+        res = req.get_response(prosrv)
+        self.assertEqual(res.status_int, 200)
+        out = pickle.loads(res.body)
+        self.assertNotIn('name=HTTP_X_AUTH_TOKEN, value=t', out)
+        self.assertNotIn('name=HTTP_X_STORAGE_TOKEN, value=t', out)
+        self.assertNotIn('name=HTTP_COOKIE, value=secret', out)
+        self.assertNotIn('name=HTTP_X_BACKEND_DATA, value=internal_data', out)
 
     def test_QUERY_GET_response(self):
         self.setup_QUERY()

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -609,7 +609,7 @@ class ClusterController(ObjectController):
                          get_sys_meta_prefix('container'),
                          get_sys_meta_prefix('object'),
                          'x-backend', 'x-auth', 'content-type',
-                         'content-length']
+                         'content-length', 'x-storage-token', 'cookie']
 
     def __init__(self, app, account_name, container_name, obj_name, middleware,
                  command, **kwargs):


### PR DESCRIPTION
`X-Storage-Token` and `Cookie` headers were leaked into CGI environment
There is no need for an application to know that information
