### PR TITLE
vagrant: improve the local dev env

### DIFF
--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -21,4 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Keystone admin:
   config.vm.network "forwarded_port", guest: 35357, host: 35357
 
+  # Map the local git clone folder into the vm:
+  config.vm.synced_folder "../..", "/zerocloud-root"
+
 end

--- a/contrib/vagrant/bootstrap.sh
+++ b/contrib/vagrant/bootstrap.sh
@@ -25,9 +25,9 @@ echo "$LOCAL_CONF" >> local.conf
 
 ###
 # ZeroCloud
-git clone https://github.com/zerovm/zerocloud.git $HOME/zerocloud
-cd $HOME/zerocloud
-sudo python setup.py install
+# Install is from the code on the host, mapped to /zerocloud
+cd /zerocloud-root
+sudo python setup.py develop
 
 ###
 # Python system image for ZeroCloud/ZeroVM


### PR DESCRIPTION
The git clone on the host is now mapped in to the VM, and changes to the
code in the host dev environment will be reflected inside the VM (after
restarting devstack, of course).

This makes it a lot easier to experiment, debug, and test in a "real"
environment (and not just with the test suite).
