### PR TITLE
Debug logging for `zerovm_query`

### DIFF
--- a/contrib/vagrant/configure_swift.py
+++ b/contrib/vagrant/configure_swift.py
@@ -13,11 +13,11 @@ def inject_before(some_list, item, target):
     return some_list
 
 
-def config_add_filter(file_path, filter_name, func_name, inject_b4,
+def config_add_filter(cp, filter_name, func_name, inject_b4,
                       extras=None):
     """
-    :param file_path:
-        Path to the Swift config file.
+    :param cp:
+        :class:`ConfigParser.ConfigParser` object
     :param filter_name:
         Name of the filter. This is the name that will be used to reference the
         filter in the pipeline configuration.
@@ -27,8 +27,6 @@ def config_add_filter(file_path, filter_name, func_name, inject_b4,
         When inserting a filter into the pipeline, place the filter (indicated
         by `filter_name`) before `inject_b4`.
     """
-    cp = ConfigParser()
-    cp.read(file_path)
     filt = 'filter:%s' % filter_name
     cp.add_section(filt)
     cp.set(filt, 'use', 'egg:zerocloud#%s' % func_name)
@@ -41,14 +39,15 @@ def config_add_filter(file_path, filter_name, func_name, inject_b4,
     pipeline = inject_before(pipeline, filter_name, inject_b4)
     cp.set('pipeline:main', 'pipeline', value=' '.join(pipeline))
 
-    with open(file_path, 'w') as fp:
-        cp.write(fp)
-
 
 if __name__ == '__main__':
+    # Object server:
+    cp = ConfigParser()
+    obj_server = '/etc/swift/object-server/1.conf'
+    cp.read(obj_server)
     # basic ZeroVM object server config
     config_add_filter(
-        '/etc/swift/object-server/1.conf',
+        cp,
         'object-query',
         'object_query',
         'object-server',
@@ -56,10 +55,16 @@ if __name__ == '__main__':
             'zerovm_sysimage_devices': 'python2.7 /usr/share/zerovm/python.tar'
         }
     )
+    with open(obj_server, 'w') as fp:
+        cp.write(fp)
 
+    # Proxy server:
+    cp = ConfigParser()
+    proxy_server = '/etc/swift/proxy-server.conf'
+    cp.read(proxy_server)
     # basic ZeroVM proxy server config
     config_add_filter(
-        '/etc/swift/proxy-server.conf',
+        cp,
         'proxy-query',
         'proxy_query',
         'proxy-server',
@@ -67,16 +72,22 @@ if __name__ == '__main__':
             'zerovm_sysimage_devices': 'python2.7 /usr/share/zerovm/python.tar'
         }
     )
-
     # proxy server job chaining middleware
     config_add_filter(
-        '/etc/swift/proxy-server.conf',
+        cp,
         'job-chain',
         'job_chain',
         'proxy-query'
     )
+    with open(proxy_server, 'w') as fp:
+        cp.write(fp)
+
+    # Container server:
+    cp = ConfigParser()
+    cont_server = '/etc/swift/container-server/1.conf',
+    cp.read(cont_server)
     config_add_filter(
-        '/etc/swift/container-server/1.conf',
+        cp,
         'object-query',
         'object_query',
         'container-server',
@@ -84,3 +95,5 @@ if __name__ == '__main__':
             'zerovm_sysimage_devices': 'python2.7 /usr/share/zerovm/python.tar'
         }
     )
+    with open(cont_server, 'w') as fp:
+        cp.write(fp)

--- a/contrib/vagrant/configure_swift.py
+++ b/contrib/vagrant/configure_swift.py
@@ -55,6 +55,8 @@ if __name__ == '__main__':
             'zerovm_sysimage_devices': 'python2.7 /usr/share/zerovm/python.tar'
         }
     )
+    # Set verbose logging on the object server
+    cp.set('DEFAULT', 'log_level', 'DEBUG')
     with open(obj_server, 'w') as fp:
         cp.write(fp)
 

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -23,6 +23,7 @@ from swift.common.swob import Request, Response, HTTPNotFound, \
     HTTPBadRequest, HTTPUnprocessableEntity, HTTPServiceUnavailable, \
     HTTPClientDisconnect, HTTPInternalServerError, HeaderKeyDict, \
     HTTPInsufficientStorage
+from swift.common.swob import HTTPException
 from swift.common.utils import normalize_timestamp, \
     get_logger, mkdirs, disable_fallocate, config_true_value, \
     hash_path, storage_directory
@@ -638,8 +639,12 @@ class ObjectQueryMiddleware(object):
         :returns:
             :class:`swift.common.swob.Response`
         """
-        resp = self._do_zerovm_query(req)
-        return resp
+        try:
+            resp = self._do_zerovm_query(req)
+            return resp
+        except HTTPException as http_exc:
+            resp = req.get_response(http_exc)
+            return resp
 
     def _do_zerovm_query(self, req):
         debug_dir = self._debug_init(req)
@@ -648,7 +653,7 @@ class ObjectQueryMiddleware(object):
             daemon_sock = os.path.join(self.zerovm_sockets_dir, daemon_sock)
         job_id = req.headers.get('x-zerocloud-id', None)
         if not job_id:
-            return HTTPInternalServerError(request=req)
+            raise HTTPInternalServerError(request=req)
         # print "URL: " + req.url
         nexe_headers = {
             'x-nexe-retcode': 0,
@@ -666,20 +671,20 @@ class ObjectQueryMiddleware(object):
         rbytes = self.parser_config['limits']['rbytes']
         if 'content-length' in req.headers \
                 and int(req.headers['content-length']) > rbytes:
-            return HTTPRequestEntityTooLarge(body='RPC request too large',
-                                             request=req,
-                                             content_type='text/plain',
-                                             headers=nexe_headers)
+            raise HTTPRequestEntityTooLarge(body='RPC request too large',
+                                            request=req,
+                                            content_type='text/plain',
+                                            headers=nexe_headers)
         if 'content-type' not in req.headers:
-            return HTTPBadRequest(request=req,
-                                  content_type='text/plain',
-                                  body='No content type',
-                                  headers=nexe_headers)
+            raise HTTPBadRequest(request=req,
+                                 content_type='text/plain',
+                                 body='No content type',
+                                 headers=nexe_headers)
         if not req.headers['Content-Type'] in TAR_MIMES:
-            return HTTPBadRequest(request=req,
-                                  body='Invalid Content-Type',
-                                  content_type='text/plain',
-                                  headers=nexe_headers)
+            raise HTTPBadRequest(request=req,
+                                 body='Invalid Content-Type',
+                                 content_type='text/plain',
+                                 headers=nexe_headers)
         access_type = req.headers.get('x-zerovm-access', '')
         if obj:
             try:
@@ -691,20 +696,20 @@ class ObjectQueryMiddleware(object):
                                        obj,
                                        policy_idx)
             except DiskFileDeviceUnavailable:
-                return HTTPInsufficientStorage(drive=device,
-                                               request=req)
+                raise HTTPInsufficientStorage(drive=device,
+                                              request=req)
             if access_type == 'GET':
                 try:
                     local_object.disk_file.open()
                 except DiskFileNotExist:
-                    return HTTPNotFound(request=req)
+                    raise HTTPNotFound(request=req)
             elif access_type == 'PUT':
                 try:
                     local_object.disk_file.new_timestamp = \
                         req.headers.get('x-timestamp')
                     float(local_object.disk_file.new_timestamp)
                 except (KeyError, ValueError, TypeError):
-                    return HTTPBadRequest(
+                    raise HTTPBadRequest(
                         body='Locally writable object '
                              'specified but no x-timestamp '
                              'in request')
@@ -715,26 +720,26 @@ class ObjectQueryMiddleware(object):
                         device, partition,
                         account, container)
                 if local_object.broker.is_deleted():
-                    return HTTPNotFound(headers=nexe_headers,
-                                        request=req)
+                    raise HTTPNotFound(headers=nexe_headers,
+                                       request=req)
             else:
-                return HTTPBadRequest(
+                raise HTTPBadRequest(
                     body='Containers should be read-only',
                     headers=nexe_headers)
         pool = req.headers.get('x-zerovm-pool', 'default').lower()
         thrdpool = self.zerovm_thread_pools.get(pool, None)
         if not thrdpool:
-            return HTTPBadRequest(body='Cannot find pool %s' % pool,
-                                  request=req, content_type='text/plain',
-                                  headers=nexe_headers)
+            raise HTTPBadRequest(body='Cannot find pool %s' % pool,
+                                 request=req, content_type='text/plain',
+                                 headers=nexe_headers)
         if not thrdpool.can_spawn(job_id):
             # if can_spawn() returned True it actually means
             # that spawn() will always succeed
             # unless something really bad happened
-            return HTTPServiceUnavailable(body='Slot not available',
-                                          request=req,
-                                          content_type='text/plain',
-                                          headers=nexe_headers)
+            raise HTTPServiceUnavailable(body='Slot not available',
+                                         request=req,
+                                         content_type='text/plain',
+                                         headers=nexe_headers)
         zerovm_valid = False
         if config_true_value(req.headers.get('x-zerovm-valid', 'false')):
             zerovm_valid = True
@@ -755,14 +760,14 @@ class ObjectQueryMiddleware(object):
             for chunk in read_iter:
                 perf = "%s %.3f" % (perf, time.time() - start)
                 if req.body_file.position > rbytes:
-                    return HTTPRequestEntityTooLarge(
+                    raise HTTPRequestEntityTooLarge(
                         body='RPC request too large',
                         request=req,
                         content_type='text/plain',
                         headers=nexe_headers)
                 if time.time() > upload_expiration:
-                    return HTTPRequestTimeout(request=req,
-                                              headers=nexe_headers)
+                    raise HTTPRequestTimeout(request=req,
+                                             headers=nexe_headers)
                 untar_stream.update_buffer(chunk)
                 info = untar_stream.get_next_tarinfo()
                 while info:
@@ -785,7 +790,7 @@ class ObjectQueryMiddleware(object):
                                                            info.name,
                                                            time.time() - start)
                             except zlib.error:
-                                return HTTPUnprocessableEntity(
+                                raise HTTPUnprocessableEntity(
                                     request=req,
                                     body='Failed to inflate gzipped image',
                                     headers=nexe_headers)
@@ -796,8 +801,8 @@ class ObjectQueryMiddleware(object):
                                     % (req.headers['content-length'],
                                        req.body_file.position,
                                        str(req.headers)))
-                return HTTPClientDisconnect(request=req,
-                                            headers=nexe_headers)
+                raise HTTPClientDisconnect(request=req,
+                                           headers=nexe_headers)
             perf = "%s %.3f" % (perf, time.time() - start)
             if self.zerovm_perf:
                 self.logger.info("PERF UNTAR: %s" % perf)
@@ -807,11 +812,11 @@ class ObjectQueryMiddleware(object):
                     try:
                         config = json.load(fp)
                     except ValueError:
-                        return HTTPBadRequest(request=req,
-                                              body='Cannot parse system map')
+                        raise HTTPBadRequest(request=req,
+                                             body='Cannot parse system map')
             else:
-                return HTTPBadRequest(request=req,
-                                      body='No system map found in request')
+                raise HTTPBadRequest(request=req,
+                                     body='No system map found in request')
 
             nexe_headers['x-nexe-system'] = config.get('name', '')
             # print json.dumps(config, indent=2)
@@ -834,8 +839,8 @@ class ObjectQueryMiddleware(object):
             if 'boot' in channels:
                 zerovm_nexe = channels.pop('boot')
             elif not daemon_sock:
-                return HTTPBadRequest(request=req,
-                                      body='No executable found in request')
+                raise HTTPBadRequest(request=req,
+                                     body='No executable found in request')
             is_master = True
             replicate = config.get('replicate', 1)
             if replicate > 1 \
@@ -853,7 +858,7 @@ class ObjectQueryMiddleware(object):
                                 meta = local_object.disk_file.get_metadata()
                                 input_file_size = int(meta['Content-Length'])
                                 if input_file_size > rbytes:
-                                    return HTTPRequestEntityTooLarge(
+                                    raise HTTPRequestEntityTooLarge(
                                         body='Data object too large',
                                         request=req,
                                         content_type='text/plain',
@@ -873,7 +878,7 @@ class ObjectQueryMiddleware(object):
                                     self.os_interface.path.getsize(
                                         local_object.broker.db_file)
                                 if input_file_size > rbytes:
-                                    return HTTPRequestEntityTooLarge(
+                                    raise HTTPRequestEntityTooLarge(
                                         body='Data object too large',
                                         request=req,
                                         headers=nexe_headers)
@@ -891,7 +896,7 @@ class ObjectQueryMiddleware(object):
                     if not ch.get('lpath'):
                         if not chan_path or is_image_path(chan_path)\
                                 or is_swift_path(chan_path):
-                            return HTTPBadRequest(
+                            raise HTTPBadRequest(
                                 request=req,
                                 body='Could not resolve channel path %s for '
                                      'device: %s' % (ch['path'], ch['device']))
@@ -934,14 +939,14 @@ class ObjectQueryMiddleware(object):
                         sysimage_path = \
                             self.parser.get_sysimage(exe_path.image)
                         if not sysimage_path:
-                            return HTTPInternalServerError(
+                            raise HTTPInternalServerError(
                                 body='System image does not exist: %s'
                                      % exe_path.image)
                         if not self._extract_boot_file(channels,
                                                        exe_path.path,
                                                        sysimage_path,
                                                        zerovm_tmp):
-                            return HTTPInternalServerError(
+                            raise HTTPInternalServerError(
                                 body='Cannot find daemon nexe '
                                      'in system image %s'
                                      % sysimage_path)
@@ -965,7 +970,7 @@ class ObjectQueryMiddleware(object):
                             # something strange happened, let's log it
                             self.logger.warning('Slot not available after '
                                                 'can_spawn() succeeded')
-                            return HTTPServiceUnavailable(
+                            raise HTTPServiceUnavailable(
                                 body='Slot not available',
                                 request=req,
                                 content_type='text/plain',
@@ -1011,7 +1016,7 @@ class ObjectQueryMiddleware(object):
                                                   sock,
                                                   zerovm_inputmnfst, timeout)
                         except IOError:
-                            return HTTPInternalServerError(
+                            raise HTTPInternalServerError(
                                 body='Cannot connect to daemon '
                                      'even after daemon restart: '
                                      'socket %s' % daemon_sock,
@@ -1034,10 +1039,10 @@ class ObjectQueryMiddleware(object):
                     # something strange happened, let's log it
                     self.logger.warning('Slot not available after '
                                         'can_spawn() succeeded')
-                    return HTTPServiceUnavailable(body='Slot not available',
-                                                  request=req,
-                                                  content_type='text/plain',
-                                                  headers=nexe_headers)
+                    raise HTTPServiceUnavailable(body='Slot not available',
+                                                 request=req,
+                                                 content_type='text/plain',
+                                                 headers=nexe_headers)
                 (zerovm_retcode, zerovm_stdout, zerovm_stderr) = thrd.wait()
                 perf = "%.3f" % (time.time() - start)
                 if self.zerovm_perf:

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -638,7 +638,10 @@ class ObjectQueryMiddleware(object):
         :returns:
             :class:`swift.common.swob.Response`
         """
+        resp = self._do_zerovm_query(req)
+        return resp
 
+    def _do_zerovm_query(self, req):
         debug_dir = self._debug_init(req)
         daemon_sock = req.headers.get('x-zerovm-daemon', None)
         if daemon_sock:

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -657,7 +657,8 @@ class ObjectQueryMiddleware(object):
             daemon_sock = os.path.join(self.zerovm_sockets_dir, daemon_sock)
         job_id = req.headers.get('x-zerocloud-id', None)
         if not job_id:
-            raise HTTPInternalServerError(request=req)
+            raise HTTPInternalServerError(
+                request=req, body='X-Zerocloud-Id header is missing')
         # print "URL: " + req.url
         nexe_headers = {
             'x-nexe-retcode': 0,

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -641,9 +641,13 @@ class ObjectQueryMiddleware(object):
         """
         try:
             resp = self._do_zerovm_query(req)
+            self.logger.debug("zerovm_query: %(status)s",
+                              dict(status=resp.status))
             return resp
         except HTTPException as http_exc:
             resp = req.get_response(http_exc)
+            self.logger.debug("zerovm_query: %(status)s - %(body)s",
+                              dict(status=resp.status, body=resp.body))
             return resp
 
     def _do_zerovm_query(self, req):


### PR DESCRIPTION
Partially addresses https://github.com/zerovm/zerocloud/issues/106.

This change add debug logging output for all of the HTTP responses returned by `zerovm_query`. This includes a change to the way the responses are propagated. Instead of `return` statements, HTTP response can be raised as exceptions. This helps in a couple of ways:
1. We can differentiate "normal" or "successful" responses from error conditions.
2. We can do slightly different logging depending on the case. In the successful case, it's not really necessary to log the response body: with the current implementation, there is no body. In the error cases, the body includes a helpful message explaining the problem, so that's good to have in the logs.
3. This allows us to be more flexible in refactoring `zerovm_query`. I find this large method difficult to reason about in its entirety, and I would like to break it up into a handful of smaller methods.
