### PR TITLE
move some exception handling to a better place

### DIFF
--- a/test/unit/test_objectquery.py
+++ b/test/unit/test_objectquery.py
@@ -1152,7 +1152,7 @@ class TestObjectQuery(unittest.TestCase):
                         'default'] = WaitPool(size, queue)
                     spil_over = size + queue
                     for i in r:
-                        t[i] = pool.spawn(self.app.zerovm_query, req[i])
+                        t[i] = pool.spawn(req[i].get_response, self.app)
                     pool.waitall()
                     resp = copy(r)
                     for i in r[:spil_over]:


### PR DESCRIPTION
HTTPExceptions should be handled in the outmost callable
that way it's easier to catch all the exceptions that may arise anywhere in objectquery code
strategically moved all the debug logging and exception handling into `__call__` method of the middleware
