### PR TITLE
improve zerovm return code handling

### DIFF
--- a/test/unit/zerovm_mock.py
+++ b/test/unit/zerovm_mock.py
@@ -290,6 +290,7 @@ except Exception:
 
 zvm_environ = read_env(mnfst.nvram['path'])
 od = ''
+error_code = 0
 try:
     od = str(eval_as_function(exe))
 except Exception, e:
@@ -326,4 +327,4 @@ err.close()
 if mnfst.err['etag']:
     mnfst.err['etag'] = mnfst.err['etag'].hexdigest()
     mnfst.Etag += ' %s %s' % (mnfst.err['device'], mnfst.err['etag'])
-errdump(0, valid, retcode, mnfst.Etag, accounting, 'ok.')
+errdump(error_code, valid, retcode, mnfst.Etag, accounting, 'ok.')

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -1395,6 +1395,8 @@ class ClusterController(ObjectController):
             return conn
         if resp.content_length == 0:
             return conn
+        if 'x-nexe-error' in resp.headers:
+            resp.status = 500
         node = conn.cnode
         untar_stream = UntarStream(resp.app_iter)
         bytes_transferred = 0


### PR DESCRIPTION
zerovm can produce non-zero return codes when something abnormal happens not only in zerovm, but in untrusted code also
developer needs context of the problem, for that reason we try to save all output we've got to the places specified in job description file and do not discard it
we also set HTTP status 500 on the response where at least one node failed with bad return code
did some refactoring of the functions in the vicinity of error code handling to better isolate the issue
