### PR TITLE
remove some sysimage_devices checks

### DIFF
--- a/test/unit/test_objectquery.py
+++ b/test/unit/test_objectquery.py
@@ -1463,10 +1463,9 @@ class TestObjectQuery(unittest.TestCase):
             req.body_file = Input(open(tar, 'rb'), length)
             req.content_length = length
             resp = req.get_response(self.app)
-            fd, name = mkstemp()
             self.assertEqual(resp.status_int, 400)
             self.assertEqual(
-                resp.body, 'Could not resolve channel path bla-bla for '
+                resp.body, 'Could not resolve channel path "bla-bla" for '
                            'device: stdin')
 
     def test_QUERY_filter_factory(self):

--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -2501,7 +2501,8 @@ class TestProxyQuery(unittest.TestCase):
         req.body = conf
         res = req.get_response(prosrv)
         self.assertEqual(res.status_int, 400)
-        self.assertEqual(res.body, 'Unknown device stdtest in sort')
+        self.assertEqual(res.body, 'Could not resolve channel path "" for '
+                                   'device: stdtest')
         conf = [
             {
                 'name': 'sort',
@@ -2647,7 +2648,7 @@ class TestProxyQuery(unittest.TestCase):
             res = req.get_response(prosrv)
             self.assertEqual(res.status_int, 400)
             self.assertEqual(res.body, ('Could not resolve channel path '
-                                        'swift://a/%s for device: stdin'
+                                        '"swift://a/%s" for device: stdin'
                                         % path) * 2)
             self.assertEqual(res.headers['x-nexe-system'], 'sort,sort')
             self.assertEqual(res.headers['x-nexe-status'],

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -909,12 +909,13 @@ class ObjectQueryMiddleware(object):
                     ch['lpath'] = self.parser.get_sysimage(ch['device'])
                 elif ch['access'] & (ACCESS_READABLE | ACCESS_CDR):
                     if not ch.get('lpath'):
-                        if not chan_path or is_image_path(chan_path)\
+                        if not chan_path or is_image_path(chan_path) \
                                 or is_swift_path(chan_path):
                             raise HTTPBadRequest(
                                 request=req,
-                                body='Could not resolve channel path %s for '
-                                     'device: %s' % (ch['path'], ch['device']))
+                                body='Could not resolve channel path "%s" for '
+                                     'device: %s' % (ch['path'] or '',
+                                                     ch['device']))
                 elif ch['access'] & ACCESS_WRITABLE:
                     writable_tmpdir = self.get_writable_tmpdir(device)
                     (output_fd, output_fn) = mkstemp(dir=writable_tmpdir)

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -620,7 +620,7 @@ class ClusterController(ObjectController):
         self.middleware = middleware
         self.command = command
         self.parser = ClusterConfigParser(
-            self.middleware.zerovm_sysimage_devices,
+            {},
             self.middleware.zerovm_content_type,
             self.middleware.parser_config,
             self.middleware.list_account,


### PR DESCRIPTION
this patch removes some redundant checks from ClusterController
sysimages are resolved on objectquery middleware, no need to sanity check it on proxyquery
