### PR TITLE
fix empty stdin from request

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -3428,7 +3428,8 @@ class TestProxyQuery(unittest.TestCase):
             req.body_file = open(tar, 'rb')
             req.content_length = os.path.getsize(tar)
             res = req.get_response(prosrv)
-            self.assertEqual(res.status_int, 400)
+            self.assertEqual(res.status_int, 200)
+            self.assertEqual(res.body, '')
             self.create_object(prolis, '/v1/a/c/myapp',
                                open(tar, 'rb').read(),
                                content_type='application/x-tar')

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -907,6 +907,9 @@ class ObjectQueryMiddleware(object):
                         local_object.channel = ch
                 if self.parser.is_sysimage_device(ch['device']):
                     ch['lpath'] = self.parser.get_sysimage(ch['device'])
+                elif not ch['path'] and not ch.get('lpath') \
+                        and ch['device'] == 'stdin':
+                    ch['lpath'] = '/dev/null'
                 elif ch['access'] & (ACCESS_READABLE | ACCESS_CDR):
                     if not ch.get('lpath'):
                         if not chan_path or is_image_path(chan_path) \


### PR DESCRIPTION
in some requests the stdin channel can be attached to request data
if the request data is empty the channel local path was unpopulated which lead to HTTP 400
this patch will populate the local path for `stdin` with `/dev/null` in such case (this is a standard behavior for CGI)
fixes issue #152
