### PR TITLE
zerocloud, all modules: one import per line

### DIFF
--- a/zerocloud/chain.py
+++ b/zerocloud/chain.py
@@ -1,7 +1,10 @@
 from time import time
 from swift.common.swob import Request
-from swift.common.utils import split_path, get_logger
-from swift.common.wsgi import WSGIContext, make_subrequest, CloseableChain
+from swift.common.utils import split_path
+from swift.common.utils import get_logger
+from swift.common.wsgi import WSGIContext
+from swift.common.wsgi import make_subrequest
+from swift.common.wsgi import CloseableChain
 from zerocloud.proxyquery import is_zerocloud_request
 
 

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -3,7 +3,8 @@ import re
 from hashlib import md5
 
 from swift.common.swob import Response
-from swift.common.utils import split_path, readconf
+from swift.common.utils import split_path
+from swift.common.utils import readconf
 
 
 try:

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -1,9 +1,19 @@
 import re
 import traceback
-from zerocloud.common import SwiftPath, ZvmNode, ZvmChannel, is_zvm_path, \
-    ACCESS_READABLE, ACCESS_CDR, ACCESS_WRITABLE, parse_location, \
-    ACCESS_RANDOM, has_control_chars, DEVICE_MAP, is_swift_path, \
-    ACCESS_NETWORK, expand_account_path
+from zerocloud.common import SwiftPath
+from zerocloud.common import ZvmNode
+from zerocloud.common import ZvmChannel
+from zerocloud.common import is_zvm_path
+from zerocloud.common import ACCESS_READABLE
+from zerocloud.common import ACCESS_CDR
+from zerocloud.common import ACCESS_WRITABLE
+from zerocloud.common import parse_location
+from zerocloud.common import ACCESS_RANDOM
+from zerocloud.common import has_control_chars
+from zerocloud.common import DEVICE_MAP
+from zerocloud.common import is_swift_path
+from zerocloud.common import ACCESS_NETWORK
+from zerocloud.common import expand_account_path
 
 CHANNEL_TYPE_MAP = {
     'stdin': 0,

--- a/zerocloud/objectquery.py
+++ b/zerocloud/objectquery.py
@@ -6,9 +6,13 @@ import traceback
 import tarfile
 from contextlib import contextmanager
 from hashlib import md5
-from tempfile import mkstemp, mkdtemp
+from tempfile import mkstemp
+from tempfile import mkdtemp
 
-from eventlet.green import select, subprocess, os, socket
+from eventlet.green import select
+from eventlet.green import subprocess
+from eventlet.green import os
+from eventlet.green import socket
 from eventlet.timeout import Timeout
 from eventlet.green.httplib import HTTPResponse
 import errno
@@ -18,32 +22,68 @@ import zlib
 from os.path import exists
 from swift.common.request_helpers import get_name_and_placement
 from swift.common.storage_policy import POLICIES
-from swift.common.swob import Request, Response, HTTPNotFound, \
-    HTTPPreconditionFailed, HTTPRequestTimeout, HTTPRequestEntityTooLarge, \
-    HTTPBadRequest, HTTPUnprocessableEntity, HTTPServiceUnavailable, \
-    HTTPClientDisconnect, HTTPInternalServerError, HeaderKeyDict, \
-    HTTPInsufficientStorage, HTTPMethodNotAllowed
+from swift.common.swob import Request
+from swift.common.swob import Response
+from swift.common.swob import HTTPNotFound
+from swift.common.swob import HTTPPreconditionFailed
+from swift.common.swob import HTTPRequestTimeout
+from swift.common.swob import HTTPRequestEntityTooLarge
+from swift.common.swob import HTTPBadRequest
+from swift.common.swob import HTTPUnprocessableEntity
+from swift.common.swob import HTTPServiceUnavailable
+from swift.common.swob import HTTPClientDisconnect
+from swift.common.swob import HTTPInternalServerError
+from swift.common.swob import HeaderKeyDict
+from swift.common.swob import HTTPInsufficientStorage
+from swift.common.swob import HTTPMethodNotAllowed
 from swift.common.swob import HTTPException
-from swift.common.utils import normalize_timestamp, \
-    get_logger, mkdirs, disable_fallocate, config_true_value, \
-    hash_path, storage_directory, get_log_line
+from swift.common.utils import normalize_timestamp
+from swift.common.utils import get_logger
+from swift.common.utils import mkdirs
+from swift.common.utils import disable_fallocate
+from swift.common.utils import config_true_value
+from swift.common.utils import hash_path
+from swift.common.utils import storage_directory
+from swift.common.utils import get_log_line
 from swift.container.backend import ContainerBroker
-from swift.obj.diskfile import DiskFileManager, DiskFile, DiskFileWriter, \
-    write_metadata
+from swift.obj.diskfile import DiskFileManager
+from swift.obj.diskfile import DiskFile
+from swift.obj.diskfile import DiskFileWriter
+from swift.obj.diskfile import write_metadata
 from swift.common.constraints import check_utf8
-from swift.common.exceptions import DiskFileNotExist, DiskFileNoSpace, \
-    DiskFileDeviceUnavailable, DiskFileQuarantined
+from swift.common.exceptions import DiskFileNotExist
+from swift.common.exceptions import DiskFileNoSpace
+from swift.common.exceptions import DiskFileDeviceUnavailable
+from swift.common.exceptions import DiskFileQuarantined
 from swift.proxy.controllers.base import update_headers
-from zerocloud.common import TAR_MIMES, ACCESS_READABLE, ACCESS_CDR, \
-    ACCESS_WRITABLE, MD5HASH_LENGTH, parse_location, is_image_path, \
-    ACCESS_NETWORK, ACCESS_RANDOM, REPORT_VALIDATOR, REPORT_RETCODE, \
-    REPORT_ETAG, REPORT_CDR, REPORT_STATUS, SwiftPath, REPORT_LENGTH, \
-    REPORT_DAEMON, load_server_conf, is_swift_path, TIMEOUT_GRACE
+from zerocloud.common import TAR_MIMES
+from zerocloud.common import ACCESS_READABLE
+from zerocloud.common import ACCESS_CDR
+from zerocloud.common import ACCESS_WRITABLE
+from zerocloud.common import MD5HASH_LENGTH
+from zerocloud.common import parse_location
+from zerocloud.common import is_image_path
+from zerocloud.common import ACCESS_NETWORK
+from zerocloud.common import ACCESS_RANDOM
+from zerocloud.common import REPORT_VALIDATOR
+from zerocloud.common import REPORT_RETCODE
+from zerocloud.common import REPORT_ETAG
+from zerocloud.common import REPORT_CDR
+from zerocloud.common import REPORT_STATUS
+from zerocloud.common import SwiftPath
+from zerocloud.common import REPORT_LENGTH
+from zerocloud.common import REPORT_DAEMON
+from zerocloud.common import load_server_conf
+from zerocloud.common import is_swift_path
+from zerocloud.common import TIMEOUT_GRACE
 from zerocloud.configparser import ClusterConfigParser
 from zerocloud.proxyquery import gunzip_iter
-
-from zerocloud.tarstream import UntarStream, TarStream, \
-    REGTYPE, BLOCKSIZE, NUL, PAX_FORMAT
+from zerocloud.tarstream import UntarStream
+from zerocloud.tarstream import TarStream
+from zerocloud.tarstream import REGTYPE
+from zerocloud.tarstream import BLOCKSIZE
+from zerocloud.tarstream import NUL
+from zerocloud.tarstream import PAX_FORMAT
 import zerocloud.thread_pool as zpool
 
 try:

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -10,7 +10,10 @@ import uuid
 from hashlib import md5
 from random import randrange, choice
 import greenlet
-from eventlet import GreenPile, GreenPool, Queue, spawn_n
+from eventlet import GreenPile
+from eventlet import GreenPool
+from eventlet import Queue
+from eventlet import spawn_n
 from eventlet.green import socket
 from eventlet.timeout import Timeout
 import zlib
@@ -20,36 +23,79 @@ from swift.common.storage_policy import POLICIES
 from swift.common.request_helpers import get_sys_meta_prefix
 from swift.common.wsgi import make_subrequest
 from swiftclient.client import quote
-from swift.common.http import HTTP_CONTINUE, is_success, \
-    HTTP_INSUFFICIENT_STORAGE, is_client_error, HTTP_NOT_FOUND, \
-    HTTP_REQUESTED_RANGE_NOT_SATISFIABLE
-from swift.proxy.controllers.base import update_headers, delay_denial, \
-    cors_validation, get_info, close_swift_conn
-from swift.common.utils import split_path, get_logger, TRUE_VALUES, \
-    get_remote_client, ContextPool, cache_from_env, normalize_timestamp, \
-    GreenthreadSafeIterator
-from swift.proxy.server import ObjectController, ContainerController, \
-    AccountController
+from swift.common.http import HTTP_CONTINUE
+from swift.common.http import is_success
+from swift.common.http import HTTP_INSUFFICIENT_STORAGE
+from swift.common.http import is_client_error
+from swift.common.http import HTTP_NOT_FOUND
+from swift.common.http import HTTP_REQUESTED_RANGE_NOT_SATISFIABLE
+from swift.proxy.controllers.base import update_headers
+from swift.proxy.controllers.base import delay_denial
+from swift.proxy.controllers.base import cors_validation
+from swift.proxy.controllers.base import get_info
+from swift.proxy.controllers.base import close_swift_conn
+from swift.common.utils import split_path
+from swift.common.utils import get_logger
+from swift.common.utils import TRUE_VALUES
+from swift.common.utils import get_remote_client
+from swift.common.utils import ContextPool
+from swift.common.utils import cache_from_env
+from swift.common.utils import normalize_timestamp
+from swift.common.utils import GreenthreadSafeIterator
+from swift.proxy.server import ObjectController
+from swift.proxy.server import ContainerController
+from swift.proxy.server import AccountController
 from swift.common.bufferedhttp import http_connect
-from swift.common.exceptions import ConnectionTimeout, ChunkReadTimeout
-from swift.common.constraints import check_utf8, MAX_FILE_SIZE, MAX_HEADER_SIZE, \
-    MAX_META_NAME_LENGTH, MAX_META_VALUE_LENGTH, MAX_META_COUNT, \
-    MAX_META_OVERALL_SIZE
-from swift.common.swob import Request, Response, HTTPNotFound, \
-    HTTPPreconditionFailed, HTTPRequestTimeout, HTTPRequestEntityTooLarge, \
-    HTTPBadRequest, HTTPUnprocessableEntity, HTTPServiceUnavailable, \
-    HTTPClientDisconnect, wsgify, HTTPNotImplemented, HeaderKeyDict, \
-    HTTPException
-from zerocloud.common import CLUSTER_CONFIG_FILENAME, NODE_CONFIG_FILENAME, TAR_MIMES, \
-    POST_TEXT_OBJECT_SYSTEM_MAP, POST_TEXT_ACCOUNT_SYSTEM_MAP, \
-    merge_headers, DEFAULT_EXE_SYSTEM_MAP, \
-    STREAM_CACHE_SIZE, parse_location, is_swift_path, \
-    is_image_path, can_run_as_daemon, SwiftPath, load_server_conf, \
-    expand_account_path, TIMEOUT_GRACE
-from zerocloud.configparser import ClusterConfigParser, \
-    ClusterConfigParsingError
-from zerocloud.tarstream import StringBuffer, UntarStream, \
-    TarStream, REGTYPE, BLOCKSIZE, NUL, ExtractedFile, Path, ReadError
+from swift.common.exceptions import ConnectionTimeout
+from swift.common.exceptions import ChunkReadTimeout
+from swift.common.constraints import check_utf8
+from swift.common.constraints import MAX_FILE_SIZE
+from swift.common.constraints import MAX_HEADER_SIZE
+from swift.common.constraints import MAX_META_NAME_LENGTH
+from swift.common.constraints import MAX_META_VALUE_LENGTH
+from swift.common.constraints import MAX_META_COUNT
+from swift.common.constraints import MAX_META_OVERALL_SIZE
+from swift.common.swob import Request
+from swift.common.swob import Response
+from swift.common.swob import HTTPNotFound
+from swift.common.swob import HTTPPreconditionFailed
+from swift.common.swob import HTTPRequestTimeout
+from swift.common.swob import HTTPRequestEntityTooLarge
+from swift.common.swob import HTTPBadRequest
+from swift.common.swob import HTTPUnprocessableEntity
+from swift.common.swob import HTTPServiceUnavailable
+from swift.common.swob import HTTPClientDisconnect
+from swift.common.swob import wsgify
+from swift.common.swob import HTTPNotImplemented
+from swift.common.swob import HeaderKeyDict
+from swift.common.swob import HTTPException
+from zerocloud.common import CLUSTER_CONFIG_FILENAME
+from zerocloud.common import NODE_CONFIG_FILENAME
+from zerocloud.common import TAR_MIMES
+from zerocloud.common import POST_TEXT_OBJECT_SYSTEM_MAP
+from zerocloud.common import POST_TEXT_ACCOUNT_SYSTEM_MAP
+from zerocloud.common import merge_headers
+from zerocloud.common import DEFAULT_EXE_SYSTEM_MAP
+from zerocloud.common import STREAM_CACHE_SIZE
+from zerocloud.common import parse_location
+from zerocloud.common import is_swift_path
+from zerocloud.common import is_image_path
+from zerocloud.common import can_run_as_daemon
+from zerocloud.common import SwiftPath
+from zerocloud.common import load_server_conf
+from zerocloud.common import expand_account_path
+from zerocloud.common import TIMEOUT_GRACE
+from zerocloud.configparser import ClusterConfigParser
+from zerocloud.configparser import ClusterConfigParsingError
+from zerocloud.tarstream import StringBuffer
+from zerocloud.tarstream import UntarStream
+from zerocloud.tarstream import TarStream
+from zerocloud.tarstream import REGTYPE
+from zerocloud.tarstream import BLOCKSIZE
+from zerocloud.tarstream import NUL
+from zerocloud.tarstream import ExtractedFile
+from zerocloud.tarstream import Path
+from zerocloud.tarstream import ReadError
 from zerocloud.thread_pool import Zuid
 
 

--- a/zerocloud/queue.py
+++ b/zerocloud/queue.py
@@ -2,13 +2,25 @@ from eventlet import Timeout
 from time import time
 import uuid
 
-from swift.common.exceptions import ListingIterNotFound, ListingIterError
-from swift.common.http import HTTP_NOT_FOUND, is_success
-from swift.common.swob import wsgify, HTTPNotFound, HTTPRequestEntityTooLarge, HTTPException, HTTPServerError, \
-    HTTPUnprocessableEntity, HTTPPreconditionFailed, Response, HTTPNoContent, \
-    HTTPCreated
-from swift.common.utils import get_logger, split_path, json, \
-    normalize_timestamp, readconf
+from swift.common.exceptions import ListingIterNotFound
+from swift.common.exceptions import ListingIterError
+from swift.common.http import HTTP_NOT_FOUND
+from swift.common.http import is_success
+from swift.common.swob import wsgify
+from swift.common.swob import HTTPNotFound
+from swift.common.swob import HTTPRequestEntityTooLarge
+from swift.common.swob import HTTPException
+from swift.common.swob import HTTPServerError
+from swift.common.swob import HTTPUnprocessableEntity
+from swift.common.swob import HTTPPreconditionFailed
+from swift.common.swob import Response
+from swift.common.swob import HTTPNoContent
+from swift.common.swob import HTTPCreated
+from swift.common.utils import get_logger
+from swift.common.utils import split_path
+from swift.common.utils import json
+from swift.common.utils import normalize_timestamp
+from swift.common.utils import readconf
 from swift.common.wsgi import make_subrequest
 from swiftclient.utils import TRUE_VALUES
 


### PR DESCRIPTION
Instead of using commas and backslashes for line continuation, having
just one import per line improves readability.

It's also easier to edit imports this way; you can just add or remove
lines. When changes like this are made, the diffs are more readable as
well.
