### PR TITLE
vagrant: don't install zerovm-cli or zpm

### DIFF
--- a/contrib/vagrant/bootstrap.sh
+++ b/contrib/vagrant/bootstrap.sh
@@ -5,7 +5,8 @@ sudo apt-get install python-software-properties --yes --force-yes
 # Add PPA for ZeroVM packages
 sudo add-apt-repository ppa:zerovm-ci/zerovm-latest -y
 sudo apt-get update
-sudo apt-get install git zerovm-cli zpm --yes --force-yes
+sudo apt-get install git python-pip zerovm --yes --force-yes
+sudo pip install python-swiftclient==2.2.0
 
 
 ###


### PR DESCRIPTION
These packages install oslo.config 1.2.1. The latest devstack needs
oslo.config 1.4, and these two are incompatible.

Technically, we don't really need the clients in the vagrant box
(although if someone wants to run zvsh, etc., inside the VM in addition
to devstack, this will be a problem). To work around this, we just
install python-swiftclient==2.2.0, which installs oslo.config 1.4.x.

NOTE: If the user installs the zerovm-cli or zpm packages inside the same VM, devstack will break. This is rather crappy.
