### PR TITLE
vagrant: pin devstack swift version

### DIFF
--- a/contrib/vagrant/bootstrap.sh
+++ b/contrib/vagrant/bootstrap.sh
@@ -20,6 +20,10 @@ ADMIN_PASSWORD=admin
 HOST_IP=127.0.0.1
 disable_all_services
 enable_service key mysql s-proxy s-object s-container s-account
+# Commit 034fae630cfd652093ef53164a7f9f43bde67336 in Swift
+# breaks ZeroCloud, completely and utterly.
+# The previous commit works:
+SWIFT_BRANCH=ca915156fb2ce4fe4356f54fb2cee7bd01185af5
 EOF
 echo "$LOCAL_CONF" >> local.conf
 ./stack.sh


### PR DESCRIPTION
A patch recently committed to Swift
(034fae630cfd652093ef53164a7f9f43bde67336) completely broke ZeroCloud. I
don't know precisely the root cause; I found the bad commit by trail and
error.

This change pins devstack installations to a version of Swift just
before this "bad" patch.
