### PR TITLE
Fix a caching issue with SwiftPath object

### DIFF
--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -1842,7 +1842,8 @@ class ApiController(RestController):
         if memcache_client:
             config = memcache_client.get(memcache_key)
             if config:
-                self.cluster_config, self.config_path = config
+                self.cluster_config, config_path_url = config
+                self.config_path = SwiftPath(config_path_url)
                 return None
         container_info = self.container_info(config_path.account,
                                              config_path.container, req)
@@ -1879,7 +1880,7 @@ class ApiController(RestController):
         if memcache_client and self.cluster_config:
             memcache_client.set(
                 memcache_key,
-                (self.cluster_config, self.config_path),
+                (self.cluster_config, self.config_path.url),
                 time=float(self.middleware.zerovm_cache_config_timeout))
         return None
 


### PR DESCRIPTION
Fixes https://github.com/zerovm/zerocloud/issues/162.

By default, Swift uses JSON encoding for caching objects in memcached.

A recent bug fix (d4d088a2932406d925c5ff304eb8835678273351) made the
assumption that cached objects were pickleable. All of the tests passed,
but I observed this break in production.
See https://github.com/zerovm/zerocloud/issues/162 for details about the
error I observed.

In general, pickling should not be used for caching objects.
There is a reference to this in Swift commit
e1ff51c04554d51616d2845f92ab726cb0e5831a.

This patch switches to using JSON encoding for storing SwiftPath objects
in memcached.
