### PR TITLE
vagrant: switch from keystone to swauth

### DIFF
--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -26,10 +26,6 @@ For a list of all releases of Vagrant, see https://dl.bintray.com/mitchellh/vagr
 
         vagrant up
 
-5. Once everything is set up, you'll need to restart Devstack in order for the
-   ZeroCloud configurations to take effect. See [Restarting DevStack and
-   ZeroCloud][restart] below.
-
 
 ### OSX
 
@@ -41,10 +37,6 @@ For a list of all releases of Vagrant, see https://dl.bintray.com/mitchellh/vagr
 3. Run Vagrant:
 
         vagrant up
-
-4. Once everything is set up, you'll need to restart DevStack in order for the
-   ZeroCloud configurations to take effect. See [Restarting DevStack and
-   ZeroCloud][restart] below.
 
 
 ## Client configuration

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -16,10 +16,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Port forwarding
   # Swift:
   config.vm.network "forwarded_port", guest: 8080, host: 8080
-  # Keystone:
-  config.vm.network "forwarded_port", guest: 5000, host: 5000
-  # Keystone admin:
-  config.vm.network "forwarded_port", guest: 35357, host: 35357
 
   # Map the local git clone folder into the vm:
   config.vm.synced_folder "../..", "/zerocloud-root"

--- a/contrib/vagrant/adminrc
+++ b/contrib/vagrant/adminrc
@@ -1,6 +1,3 @@
-export OS_REGION_NAME=RegionOne
-export OS_IDENTITY_API_VERSION=2.0
-export OS_PASSWORD=admin
-export OS_AUTH_URL=http://127.0.0.1:5000/v2.0
-export OS_USERNAME=admin
-export OS_TENANT_NAME=admin
+export ST_USER=adminacct:admin
+export ST_KEY=adminpass
+export ST_AUTH=http://127.0.0.1:8080/auth/v1.0

--- a/contrib/vagrant/demorc
+++ b/contrib/vagrant/demorc
@@ -1,6 +1,3 @@
-export OS_REGION_NAME=RegionOne
-export OS_IDENTITY_API_VERSION=2.0
-export OS_PASSWORD=demo
-export OS_AUTH_URL=http://127.0.0.1:5000/v2.0
-export OS_USERNAME=demo
-export OS_TENANT_NAME=demo
+export ST_USER=demoacct:demo
+export ST_KEY=demopass
+export ST_AUTH=http://127.0.0.1:8080/auth/v1.0

--- a/contrib/vagrant/smoketest.py
+++ b/contrib/vagrant/smoketest.py
@@ -21,8 +21,8 @@ class Smoketests(unittest.TestCase):
     def setUpClass(cls):
         # Set the storage url and auth token:
         cls.conn = swiftclient.Connection(
-            'http://127.0.0.1:5000/v2.0', 'admin', 'admin',
-            tenant_name='admin', auth_version='2.0'
+            'http://127.0.0.1:8080/auth/v1.0', 'adminacct:admin', 'adminpass',
+            auth_version='1.0'
         )
         cls.storage_url, cls.auth_token = cls.conn.get_auth()
         # TODO: if this fails, throw a useful error telling the user to run


### PR DESCRIPTION
We use swauth for our Zebra ZeroCloud deployment, so this brings the dev
environment closer to our canonical production configuration.

I also managed to figure out how to do all of the swift configuration
changes during ./stack.sh, so no devstack restart is required before
everything works--just run `vagrant up` and you're ready to go.
