### PR TITLE
vagrant: Install Swift Browser in VM

### DIFF
--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -52,7 +52,7 @@ the needed environment variables, just do:
 
 First, log in to the vagrant box:
 
-`vagrant ssh`
+    vagrant ssh
 
 Next, we need to terminate all of the DevStack processes. The first time you do
 this, you need to use a little brute force. First, run `rejoin_stack.sh`:
@@ -67,7 +67,7 @@ press 'ctrl+a backslash', then 'y' to confirm. NOTE: The first time you restart
 DevStack after provisioning the machine, not all of the Swift processes will be
 killed. A little brute force is needed:
 
-`ps ax | grep [s]wift | awk '{print $1}' | xargs kill`
+    ps ax | grep [s]wift | awk '{print $1}' | xargs kill
 
 Now restart DevStack:
 

--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -18,7 +18,8 @@
     sudo dpkg -i vagrant_1.6.3_i686.deb
     ```
 
-For a list of all releases of Vagrant, see https://dl.bintray.com/mitchellh/vagrant/.
+    For a list of all releases of Vagrant, see
+    https://dl.bintray.com/mitchellh/vagrant/.
 
 3. Change into this directory (the one with `Vagrantfile`).
 

--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -2,24 +2,13 @@
 
 ### Ubuntu Linux 12.04
 
-1. Install VirtualBox:
+1. Install VirtualBox and Vagrant:
 
-        sudo apt-get install virtualbox
+        sudo apt-get install virtualbox vagrant
 
+2. Add a 64-bit Ubuntu 12.04 LTS box to Vagrant:
 
-2. Install the latest version of Vagrant:
-
-    ```bash
-    # 64-bit
-    wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3_x86_64.deb
-    sudo dpkg -i vagrant_1.6.3_x86_64.deb
-    # 32-bit
-    wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3_i686.deb
-    sudo dpkg -i vagrant_1.6.3_i686.deb
-    ```
-
-    For a list of all releases of Vagrant, see
-    https://dl.bintray.com/mitchellh/vagrant/.
+        vagrant box add hashicorp/precise64 http://files.vagrantup.com/precise64.box
 
 3. Change into this directory (the one with `Vagrantfile`).
 

--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -6,13 +6,9 @@
 
         sudo apt-get install virtualbox vagrant
 
-2. Add a 64-bit Ubuntu 12.04 LTS box to Vagrant:
+2. Change into this directory (the one with `Vagrantfile`).
 
-        vagrant box add hashicorp/precise64 http://files.vagrantup.com/precise64.box
-
-3. Change into this directory (the one with `Vagrantfile`).
-
-4. Run Vagrant:
+3. Run Vagrant:
 
         vagrant up
 

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "hashicorp/precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.provision "shell", privileged: false, path: "bootstrap.sh"
 
   # Port forwarding

--- a/contrib/vagrant/bootstrap.sh
+++ b/contrib/vagrant/bootstrap.sh
@@ -37,8 +37,7 @@ sudo wget -q http://packages.zerovm.org/zerovm-samples/python.tar
 git clone https://github.com/openstack-dev/devstack.git $HOME/devstack
 cd $HOME/devstack
 git checkout $DEVSTACK_VERSION
-touch local.conf
-read -d '' LOCAL_CONF << EOF
+cat >> local.conf <<EOF
 [[local|localrc]]
 ADMIN_PASSWORD=admin
 HOST_IP=127.0.0.1
@@ -50,19 +49,17 @@ enable_service mysql s-proxy s-object s-container s-account
 SWIFT_BRANCH=ca915156fb2ce4fe4356f54fb2cee7bd01185af5
 KEYSTONE_BRANCH=2fc25ff9bb2480d04acae60c24079324d4abe3b0
 EOF
-echo "$LOCAL_CONF" >> local.conf
 
 # Post-config hook for configuring zerocloud (and swauth) middleware
 # for swift. This will get run during ./stack.sh, before services are
 # actually started.
 # See http://devstack.org/plugins.html for more info on how this works.
-read -d '' ZEROCLOUD_CONFIG_SCRIPT << EOF
+cat >> $HOME/devstack/extras.d/89-zerocloud.sh <<EOF
 if [[ "\$1" == "stack" && "\$2" == "post-config" ]]; then
     echo_summary "Configuring ZeroCloud middleware for Swift"
     python /vagrant/configure_swift.py
 fi
 EOF
-echo "$ZEROCLOUD_CONFIG_SCRIPT" >> $HOME/devstack/extras.d/89-zerocloud.sh
 
 ./stack.sh
 

--- a/contrib/vagrant/bootstrap.sh
+++ b/contrib/vagrant/bootstrap.sh
@@ -34,6 +34,14 @@ sudo wget -q http://packages.zerovm.org/zerovm-samples/python.tar
 
 ###
 # DevStack
+
+# Use https:// instead of git:// since the latter might be blocked by
+# firewalls whereas HTTPS is pretty much always open.
+cat >> ~/.gitconfig <<EOF
+[url "https://git.openstack"]
+	insteadOf = git://git.openstack
+EOF
+
 git clone https://github.com/openstack-dev/devstack.git $HOME/devstack
 cd $HOME/devstack
 git checkout $DEVSTACK_VERSION

--- a/contrib/vagrant/tox.ini
+++ b/contrib/vagrant/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = smoketest
+envlist = py27
 skipsdist = True
 
 [testenv]
 deps = requests
        python-swiftclient
        python-keystoneclient
-
-[testenv:smoketest]
 commands = python -m unittest smoketest


### PR DESCRIPTION
This pull request makes `bootstrap.ch` install Swift Browser into the newly created VM. It also changes the commands so that versions of Vagrant without support for Vagrant Cloud (automatic download of boxes) will work with a simple `vagrant up`.
