### PR TITLE
Tests for zerovm-suid for api/1.0 execution

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -4219,6 +4219,9 @@ class TestProxyQuery(unittest.TestCase, Utils):
 
 
 class TestAuthBase(unittest.TestCase, Utils):
+    """Base class for tests for authorization, involving the
+    ``X-Container-Meta-Zerovm-Suid`` container header.
+    """
 
     def setUp(self):
         self.setup_QUERY()
@@ -4756,6 +4759,8 @@ class TestAuthXSource(TestAuthBase):
 
 
 class TestAuthOpen(TestAuthBase):
+    """Authorization tests using the open/1.0 execution method.
+    """
 
     def test_open_owner(self):
         # test an open call to app by owner
@@ -4802,6 +4807,8 @@ class TestAuthOpen(TestAuthBase):
 
 
 class TestAuthApi(TestAuthBase):
+    """Authorization tests using the api/1.0 execution method.
+    """
 
     def test_api_anonymous(self):
         # test an api POST call to auth container by anonymous user with

--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -4789,7 +4789,6 @@ class TestAuthApi(TestAuthBase):
         # test an api POST call to auth container by anonymous user with
         # set-uid permission set allowing anonymous access
         self.remove_suid('/v1/a/auth')
-        self.remove_suid('/v1/a/auth1')
         self.set_suid('/v1/a/auth', 'swift://a/auth/myapp', '.r:*')
         conf = [
             {


### PR DESCRIPTION
These are additional tests for the zerovm-suid feature which came with https://github.com/zerovm/zerocloud/pull/172.

I need to also write some cases for open/1.0 execution, with other/anonymous users and suid.

@pkit Please have a look! 
