### PR TITLE
requirements.txt: fix eventlet dep version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 --find-links https://launchpad.net/swift/juno/2.0.0
-eventlet>=0.9.15
+eventlet>=0.9.15,<0.16
 greenlet>=0.3.1
 pastedeploy>=1.3.3
 simplejson>=2.0.9


### PR DESCRIPTION
Some API changes were made in December 2014 version 0.16, and this
breaks ZeroCloud tests.
