### PR TITLE
refactor account expansion

### DIFF
--- a/test/unit/test_proxyquery.py
+++ b/test/unit/test_proxyquery.py
@@ -179,7 +179,7 @@ class Utils(object):
             who = req.remote_user
             if req.acl == req.remote_user:
                 perm = 'Allowed'
-        what = SwiftPath.init(account, container, obj).url
+        what = SwiftPath.create_url(account, container, obj)
         ver = req.headers.get('x-zerovm-execute', 'v1')
         self.actions.append('%s %s to %s %s with %s' % (perm, who, req.method,
                                                         what, ver))

--- a/zerocloud/common.py
+++ b/zerocloud/common.py
@@ -87,14 +87,6 @@ def has_control_chars(line):
     return False
 
 
-def expand_account_path(account_name, path):
-    if path.account in ACCOUNT_HOME_PATH:
-        return SwiftPath.init(account_name,
-                              path.container,
-                              path.obj)
-    return path
-
-
 class ObjPath:
 
     def __init__(self, url, path):
@@ -127,12 +119,25 @@ class SwiftPath(ObjPath):
         self.obj = obj
 
     @classmethod
+    def create_url(cls, account, container, obj):
+        if not account:
+            return None
+        return 'swift://' + \
+               '/'.join(filter(None,
+                               (account, container, obj)))
+
+    @classmethod
     def init(cls, account, container, obj):
         if not account:
             return None
-        return cls('swift://' +
-                   '/'.join(filter(None,
-                                   (account, container, obj))))
+        return cls(SwiftPath.create_url(account, container, obj))
+
+    def expand_account(self, account_name):
+        if self.account in ACCOUNT_HOME_PATH:
+            self.account = account_name
+            self.url = SwiftPath.create_url(account_name, self.container,
+                                            self.obj)
+            self.path = self.url.split('swift:/')[1]
 
 
 class ImagePath(ObjPath):

--- a/zerocloud/configparser.py
+++ b/zerocloud/configparser.py
@@ -21,7 +21,6 @@ from zerocloud.common import ACCESS_NETWORK
 from zerocloud.common import DEVICE_MAP
 
 from zerocloud.common import has_control_chars
-from zerocloud.common import expand_account_path
 
 CHANNEL_TYPE_MAP = {
     'stdin': 0,
@@ -262,8 +261,7 @@ class ClusterConfigParser(object):
             for node in cluster_config:
                 zvm_node = ZvmNode.fromdict(node)
                 if isinstance(zvm_node.exe, SwiftPath):
-                    zvm_node.exe = expand_account_path(account_name,
-                                                       zvm_node.exe)
+                    zvm_node.exe.expand_account(account_name)
                 node_count = node.get('count', 1)
                 if isinstance(node_count, int) and node_count > 0:
                     pass
@@ -286,8 +284,7 @@ class ClusterConfigParser(object):
                                                   zvm_node)
                             continue
                         if isinstance(channel.path, SwiftPath):
-                            channel.path = expand_account_path(account_name,
-                                                               channel.path)
+                            channel.path.expand_account(account_name)
                             if not channel.path.obj \
                                     and not channel.access & ACCESS_READABLE:
                                 raise ClusterConfigParsingError(

--- a/zerocloud/proxyquery.py
+++ b/zerocloud/proxyquery.py
@@ -82,7 +82,6 @@ from zerocloud.common import parse_location
 from zerocloud import can_run_as_daemon
 from zerocloud.common import SwiftPath
 from zerocloud.common import ImagePath
-from zerocloud.common import expand_account_path
 from zerocloud import TIMEOUT_GRACE
 from zerocloud.configparser import ClusterConfigParser
 from zerocloud.configparser import ClusterConfigParsingError
@@ -1218,7 +1217,8 @@ class ClusterController(ObjectController):
                     'Content-Length': req.content_length,
                     'Content-Type': req.content_type})
             data_resp.nodes = []
-        source_loc = expand_account_path(self.account_name, source_loc)
+
+        source_loc.expand_account(self.account_name)
         source_req = make_subrequest(req.environ, method='GET',
                                      swift_source='zerocloud')
         source_req.path_info = source_loc.path


### PR DESCRIPTION
replace `expand_account_path()` with proper method on the SwiftPath instance
cleans up common zerocloud functions
